### PR TITLE
Changed TimeTracking to Timetracking since it breaks when generating class with JsonMapper on Unix machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 	    }
 	}
 	```
-3. Then run Composer's install or update commands to complete installation. 
+3. Then run Composer's install or update commands to complete installation.
 
 	```sh
 	php composer.phar install
 	```
-	
+
 4. After installing, you need to require Composer's autoloader:
 
 	```php
@@ -33,13 +33,13 @@
 
 # Configuration
 
-copy .env.example file to .env on your project root.	
-	
+copy .env.example file to .env on your project root.
+
 	JIRA_HOST="https://your-jira.host.com"
 	JIRA_USER="jira-username"
 	JIRA_PASS="jira-password"
 
-**important-note:** If you are using previous versions(a prior v1.2), you should move config.jira.json to .env and will edit it. 
+**important-note:** If you are using previous versions(a prior v1.2), you should move config.jira.json to .env and will edit it.
 
 # Usage
 
@@ -67,8 +67,8 @@ try {
 	$proj = new ProjectService();
 
 	$p = $proj->get('TEST');
-	
-	print_r($p);			
+
+	print_r($p);
 } catch (JIRAException $e) {
 	print("Error Occured! " . $e->getMessage());
 }
@@ -91,8 +91,8 @@ try {
 		echo sprintf("Project Key:%s, Id:%s, Name:%s, projectCategory: %s\n",
 			$p->key, $p->id, $p->name, $p->projectCategory['name']
 			);
-			
-	}			
+
+	}
 } catch (JIRAException $e) {
 	print("Error Occured! " . $e->getMessage());
 }
@@ -110,8 +110,8 @@ try {
 	$issueService = new IssueService();
 
 	$issue = $issueService->get('TEST-867');
-	
-	print_r($issue->fields);	
+
+	print_r($issue->fields);
 } catch (JIRAException $e) {
 	print("Error Occured! " . $e->getMessage());
 }
@@ -137,11 +137,11 @@ try {
 				->setDescription("Full description for issue")
 				->addVersion("1.0.1")
 				->addVersion("1.0.3");
-	
+
 	$issueService = new IssueService();
 
 	$ret = $issueService->create($issueField);
-	
+
 	//If success, Returns a link to the created issue.
 	print_r($ret);
 } catch (JIRAException $e) {
@@ -166,7 +166,7 @@ try {
     $issueService = new IssueService();
 
     // multiple file upload support.
-    $ret = $issueService->addAttachments($issueKey, 
+    $ret = $issueService->addAttachments($issueKey,
     	array('screen_capture.png', 'bug-description.pdf', 'README.md'));
 
     print_r($ret);
@@ -188,7 +188,7 @@ use JiraRestApi\Issue\IssueField;
 
 $issueKey = "TEST-879";
 
-try {			
+try {
 	$issueField = new IssueField(true);
 
 	$issueField->setAssigneeName("admin")
@@ -223,7 +223,7 @@ use JiraRestApi\Issue\Comment;
 
 $issueKey = "TEST-879";
 
-try {			
+try {
 	$comment = new Comment();
 
 	$body = <<<COMMENT
@@ -260,7 +260,7 @@ use JiraRestApi\Issue\Transition;
 
 $issueKey = "TEST-879";
 
-try {			
+try {
 	$transition = new Transition();
 	$transition->setTransitionName('Resolved');
 	$transition->setCommentBody('performing the transition via REST API.');
@@ -303,24 +303,24 @@ try {
 require 'vendor/autoload.php';
 
 use JiraRestApi\Issue\IssueService;
-use JiraRestApi\Issue\TimeTracking;
+use JiraRestApi\Issue\Timetracking;
 
 $issueKey = 'TEST-961';
 
 try {
     $issueService = new IssueService();
-    
+
     // get issue's time tracking info
     $ret = $issueService->getWorklog($this->issueKey);
     var_dump($ret);
-    
-    $timeTracking = new TimeTracking;
 
-    $timeTracking->setOriginalEstimate('3w 4d 6h');
-    $timeTracking->setRemainingEstimate('1w 2d 3h');
-    
+    $timetracking = new Timetracking;
+
+    $timetracking->setOriginalEstimate('3w 4d 6h');
+    $timetracking->setRemainingEstimate('1w 2d 3h');
+
     // add time tracking
-    $ret = $issueService->worklog($this->issueKey, $timeTracking);
+    $ret = $issueService->worklog($this->issueKey, $timetracking);
     var_dump($ret);
 } catch (JIRAException $e) {
     $this->assertTrue(false, 'testSearch Failed : '.$e->getMessage());

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -149,7 +149,7 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $progress;
 
-    /** @var TimeTracking */
+    /** @var Timetracking */
     public $timetracking;
 
     /** @var IssueType */

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -224,9 +224,9 @@ class IssueService extends \JiraRestApi\JiraClient
 
     /**
      * get worklog info
-     * 
-     * @param type $issueIdOrKey 
-     * @return type @TimeTracking
+     *
+     * @param type $issueIdOrKey
+     * @return type @Timetracking
      */
     public function getWorklog($issueIdOrKey)
     {
@@ -244,16 +244,16 @@ class IssueService extends \JiraRestApi\JiraClient
      * worklog issues
      *
      * @param issueIdOrKey Issue id or key
-     * @param timeTracking   TimeTracking
+     * @param timetracking   Timetracking
      *
-     * @return TimeTracking
+     * @return Timetracking
      */
-    public function worklog($issueIdOrKey, $timeTracking)
-    {   
+    public function worklog($issueIdOrKey, $timetracking)
+    {
         $array = ["update" =>
             [
                 "timetracking" => [
-                    ["edit" => $timeTracking]
+                    ["edit" => $timetracking]
                 ]
             ]
         ];
@@ -262,11 +262,11 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->addDebug("worklog req=$data\n");
 
-        $ret = $this->exec($this->uri . "/$issueIdOrKey", $data, 'PUT');   
+        $ret = $this->exec($this->uri . "/$issueIdOrKey", $data, 'PUT');
 
-        // FIXME 
+        // FIXME
         $result = $this->json_mapper->map(
-            json_decode($ret), new TimeTracking()
+            json_decode($ret), new Timetracking()
         );
 
         return $result;
@@ -274,4 +274,3 @@ class IssueService extends \JiraRestApi\JiraClient
 }
 
 ?>
-

--- a/src/Issue/TimeTracking.php
+++ b/src/Issue/TimeTracking.php
@@ -8,11 +8,11 @@
 namespace JiraRestApi\Issue;
 
 /**
- * Class TimeTracking
+ * Class Timetracking
  *
  * @package JiraRestApi\Issue
  */
-class TimeTracking implements \JsonSerializable
+class Timetracking implements \JsonSerializable
 {
     /**
      * Original estimate

--- a/tests/TimeTrackingTest.php
+++ b/tests/TimeTrackingTest.php
@@ -3,38 +3,38 @@
 require 'vendor/autoload.php';
 
 use JiraRestApi\Issue\IssueService;
-use JiraRestApi\Issue\TimeTracking;
+use JiraRestApi\Issue\Timetracking;
 
-class TimeTrackingTest extends PHPUnit_Framework_TestCase
-{    
+class TimetrackingTest extends PHPUnit_Framework_TestCase
+{
     private $issueKey = 'TEST-961';
 
-    public function testGetTimeTracking()
-    {   
+    public function testGetTimetracking()
+    {
         try {
             $issueService = new IssueService();
 
             $ret = $issueService->getWorklog($this->issueKey);
             var_dump($ret);
         } catch (JIRAException $e) {
-            $this->assertTrue(false, 'testGetTimeTracking Failed : '.$e->getMessage());
+            $this->assertTrue(false, 'testGetTimetracking Failed : '.$e->getMessage());
         }
     }
 
-    public function testPostTimeTracking()
-    {   
-        $timeTracking = new TimeTracking;
+    public function testPostTimetracking()
+    {
+        $timeTracking = new Timetracking;
 
         $timeTracking->setOriginalEstimate('3w 4d 6h');
         $timeTracking->setRemainingEstimate('1w 2d 3h');
 
         try {
             $issueService = new IssueService();
-            
+
             $ret = $issueService->worklog($this->issueKey, $timeTracking);
             var_dump($ret);
         } catch (JIRAException $e) {
-            $this->assertTrue(false, 'testPostTimeTracking Failed : '.$e->getMessage());
+            $this->assertTrue(false, 'testPostTimetracking Failed : '.$e->getMessage());
         }
     }
 }


### PR DESCRIPTION
When getting and issue from Jira, I get this exception:

`exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Class '\JiraRestApi\Issue\Timetracking' not found' in /home/www-prod/debugit/lib/vendor/netresearch/jsonmapper/src/JsonMapper.php:206`

It tries to instantiate a Time**t**racking class instead of Time**T**racking class. This seems to be since we receive from JIRA the field `timetracking` and then the JsonMapper tries to map it to an Object instance with by uppercasing the first letter of the field.

This is only a problem on unix machines, not on Windows.

Renaming the Class to `Timetracker` does the trick