### PR TITLE
Delete unexpected ":end"

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -330,7 +330,6 @@ class JiraClient
         }
 
         // clean up
-end:
         foreach ($chArr as $ch) {
             $this->log->addDebug('CURL Close handle..');
             curl_close($ch);


### PR DESCRIPTION
Don't know why it was here. Maybe an error during merging ?