### PR TITLE
Add bulk issue insert and allow assignee to be null

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you are developing with laravel framework(5.x), you must append above configu
 ### Issue
 - [Get Issue Info](#get-issue-info)  
 - [Create Issue](#create-issue)
+- [Create Issue](#create-multiple-issue)
 - [Create Sub Task](#create-sub-task)
 - [Add Attachment](#add-attachment)
 - [Update issue](#update-issue)
@@ -237,6 +238,44 @@ try {
 	print_r($ret);
 } catch (JIRAException $e) {
 	print("Error Occured! " . $e->getMessage());
+}
+
+````
+
+#### Create Multiple Issue
+
+````php
+<?php
+require 'vendor/autoload.php';
+
+use JiraRestApi\Issue\IssueService;
+use JiraRestApi\Issue\IssueField;
+
+try {
+    $issueFieldOne = new IssueField();
+
+    $issueFieldOne->setProjectKey("TEST")
+                ->setSummary("something's wrong")
+                ->setPriorityName("Critical")
+                ->setIssueType("Bug")
+                ->setDescription("Full description for issue");
+
+    $issueFieldTwo = new IssueField();
+
+    $issueFieldTwo->setProjectKey("TEST")
+                ->setSummary("something else is wrong")
+                ->setPriorityName("Critical")
+                ->setIssueType("Bug")
+                ->setDescription("Full description for second issue");
+    
+    $issueService = new IssueService();
+
+    $ret = $issueService->createMultiple([$issueFieldOne, $issueFieldTwo]);
+    
+    //If success, returns an array of the created issues
+    print_r($ret);
+} catch (JIRAException $e) {
+    print("Error Occured! " . $e->getMessage());
 }
 
 ````

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -254,7 +254,7 @@ class IssueField implements \JsonSerializable
     /** @var object */
     public $worklog;
 
-    /** @var Reporter */
+    /** @var Reporter|null */
     public $assignee;
 
     /** @var \JiraRestApi\Issue\Version[] */


### PR DESCRIPTION
@lesstif Thanks for creating this library! A couple things I wanted to update:
- Using the bulk insert endpoint for uploading large batches of issues
    - Why: Faster, and bulk insert seems to be more forgiving in that it uploads issues that are valid without throwing errors during execution
    - I'm not sure if the code fits exactly with your conventions, so let me know if you can integrate this but need some additional changes.
- Allowing assignee to be null
    - Why: I was getting an error while using the search function to find issues that did not have an assignee. Assignee isn't required on Jira so it seems like it shouldn't be necessary here.