### PR TITLE
Improved version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "netresearch/jsonmapper": "~0.11",
         "monolog/monolog": "~1.12",
         "vlucas/phpdotenv": "~2.0",
-        "symfony/var-dumper": "2.8.*|3.0.*"
+        "symfony/var-dumper": "~2.8|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",


### PR DESCRIPTION
I want to continue to use this package when switching to Laravel 5.3. However:
`laravel/framework v5.3.3 requires symfony/var-dumper 3.1.* `

Hence this pull request.

Also, shouldn't it be in require-dev?  I don't see any reason var-dumper has any use in a production environment (unsure what it's used for though)

Thanks