### PR TITLE
User Search, Custom IssueFields, External Logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "netresearch/jsonmapper": "~0.11",
         "monolog/monolog": "~1.12",
         "vlucas/phpdotenv": "~2.0",
-        "symfony/var-dumper": "2.8.*|3.0.*"
+        "symfony/var-dumper": "2.8.*|3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -165,7 +165,7 @@ class IssueField implements \JsonSerializable
     /**
      * set issue type.
      *
-     * @param IssueType $name
+     * @param \JiraRestApi\Issue\IssueType $name
      *
      * @return $this
      */
@@ -228,16 +228,16 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $progress;
 
-    /** @var TimeTracking */
+    /** @var \JiraRestApi\Issue\TimeTracking */
     public $timeTracking;
 
-    /** @var IssueType */
+    /** @var \JiraRestApi\Issue\IssueType */
     public $issuetype;
 
     /** @var string|null */
     public $timespent;
 
-    /** @var Reporter */
+    /** @var \JiraRestApi\Issue\Reporter */
     public $reporter;
 
     /** @var \DateTime */
@@ -249,10 +249,10 @@ class IssueField implements \JsonSerializable
     /** @var string|null */
     public $description;
 
-    /** @var Priority */
+    /** @var \JiraRestApi\Issue\Priority */
     public $priority;
 
-    /** @var IssueStatus */
+    /** @var \JiraRestApi\Issue\IssueStatus */
     public $status;
 
     /** @var array */
@@ -267,7 +267,7 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $components;
 
-    /** @var Comments */
+    /** @var \JiraRestApi\Issue\Comments */
     public $comment;
 
     /** @var object */
@@ -279,7 +279,7 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $fixVersions;
 
-    /** @var Reporter */
+    /** @var \JiraRestApi\Issue\Reporter */
     public $creator;
 
     /** @var object */
@@ -288,7 +288,7 @@ class IssueField implements \JsonSerializable
     /** @var object */
     public $worklog;
 
-    /** @var Reporter|null */
+    /** @var \JiraRestApi\Issue\Reporter|null */
     public $assignee;
 
     /** @var \JiraRestApi\Issue\Version[] */
@@ -315,7 +315,7 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $issuelinks;
 
-    /** @var Issue[] */
+    /** @var \JiraRestApi\Issue\Issue[] */
     public $subtasks;
 
     /** @var int */

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -24,14 +24,17 @@ class IssueService extends \JiraRestApi\JiraClient
      *
      * @param $issueIdOrKey
      * @param array $paramArray Query Parameter key-value Array.
+     * @param Issue $issueObject
      *
      * @return Issue class
      *
      * @throws JiraException
      * @throws \JsonMapper_Exception
      */
-    public function get($issueIdOrKey, $paramArray = [])
+    public function get($issueIdOrKey, $paramArray = [], $issueObject = null)
     {
+        $issueObject = ($issueObject) ? $issueObject : new Issue();
+
         $queryParam = '?'.http_build_query($paramArray);
 
         $ret = $this->exec($this->uri.'/'.$issueIdOrKey.$queryParam, null);
@@ -39,7 +42,7 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->addInfo("Result=\n".$ret);
 
         return $issue = $this->json_mapper->map(
-            json_decode($ret), new Issue()
+            json_decode($ret), $issueObject
         );
     }
 

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -58,8 +58,9 @@ class JiraClient
      * Constructor.
      *
      * @param ConfigurationInterface $configuration
+     * @param Logger $logger
      */
-    public function __construct(ConfigurationInterface $configuration = null)
+    public function __construct(ConfigurationInterface $configuration = null, Logger $logger = null)
     {
         if ($configuration === null) {
             $path = './';
@@ -74,11 +75,15 @@ class JiraClient
         $this->json_mapper = new \JsonMapper();
 
         // create logger
-        $this->log = new Logger('JiraClient');
-        $this->log->pushHandler(new StreamHandler(
-            $configuration->getJiraLogFile(),
-            $this->convertLogLevel($configuration->getJiraLogLevel())
-        ));
+        if ($logger) {
+            $this->log = $logger;
+        } else {
+            $this->log = new Logger('JiraClient');
+            $this->log->pushHandler(new StreamHandler(
+                $configuration->getJiraLogFile(),
+                $this->convertLogLevel($configuration->getJiraLogLevel())
+            ));
+        }
 
         $this->http_response = 200;
     }

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -27,8 +27,27 @@ class UserService extends \JiraRestApi\JiraClient
 
         $this->log->addInfo("Result=\n".$ret);
 
-        return $issue = $this->json_mapper->map(
+        return $this->json_mapper->map(
                 json_decode($ret), new User()
         );
+    }
+
+    public function search($paramArray)
+    {
+        $queryParam = '?'.http_build_query($paramArray);
+
+        $ret = $this->exec($this->uri.'/search'.$queryParam, null);
+
+        $this->log->addInfo("Result=\n".$ret);
+
+        $userData = json_decode($ret);
+        $users = [];
+
+        foreach($userData as $user) {
+            $users[] = $this->json_mapper->map(
+                $user, new User()
+            );
+        }
+        return $users;
     }
 }


### PR DESCRIPTION
Added search to the UserService.  Took a stab at allowing custom fields, by allowing the user to pass an instantiated object that extends from the Issue and overrides the fields object.  Allow passing in an external logger to the client.

Example custom issue and fields:

use JiraRestApi\Issue\Issue;
class JiraIssue extends Issue
{
    /**
     * @var JiraIssueField
     */
    public $fields;
}

use JiraRestApi\Issue\IssueField;
class JiraIssueField extends IssueField
{
    /** @var  string|null */
    public $customfield_10018;
    /** @var  string|null */
    public $customfield_10016;
}


