### PR TITLE
Add is_array check in IssueService::addAttachments

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -133,9 +133,10 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $resArr = array();
         foreach ($results as $ret) {
+            $ret = json_decode($ret);
             if (is_array($ret)) {
                 array_push($resArr, $this->json_mapper->mapArray(
-                   json_decode($ret), new \ArrayObject(), '\JiraRestApi\Issue\Attachment'
+                    $ret, new \ArrayObject(), '\JiraRestApi\Issue\Attachment'
                     )
                 );
             }

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -133,10 +133,12 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $resArr = array();
         foreach ($results as $ret) {
-            array_push($resArr, $this->json_mapper->mapArray(
-               json_decode($ret), new \ArrayObject(), '\JiraRestApi\Issue\Attachment'
-                )
-            );
+            if (is_array($ret)) {
+                array_push($resArr, $this->json_mapper->mapArray(
+                   json_decode($ret), new \ArrayObject(), '\JiraRestApi\Issue\Attachment'
+                    )
+                );
+            }
         }
 
         return $resArr;


### PR DESCRIPTION
Add is_array check in \JiraRestApi\Issue\IssueService::addAttachments method.

Sometimes I'm getting an error from netresearch/jsonmapper/src/JsonMapper.php:350 with message 'Invalid argument supplied for foreach()'