### PR TITLE
Comment Visibility Not Serializing

### DIFF
--- a/src/Issue/Comment.php
+++ b/src/Issue/Comment.php
@@ -2,7 +2,7 @@
 
 namespace JiraRestApi\Issue;
 
-class Visibility
+class Visibility implements \JsonSerializable
 {
     private $type;
     private $value;
@@ -23,6 +23,11 @@ class Visibility
     public function getValue()
     {
         return $this->value;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }
 


### PR DESCRIPTION
When setting a comment visibility and pushing to Jira, the visibility data is being removed because its missing the jsonSerialize() interface.