### PR TITLE
Fix 'IssueService->get' with multidimensional 'paramArray'

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -35,9 +35,9 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $queryParam = '?'.http_build_query($paramArray);
         
-		$urlPath      = $this->uri . '/' . $issueIdOrKey . $queryParam;
-		$cleanUrlPath = preg_replace('/%5B[0-9]+%5D/simU', '', $urlPath);
-		$ret          = $this->exec($cleanUrlPath, null);
+	$urlPath      = $this->uri . '/' . $issueIdOrKey . $queryParam;
+	$cleanUrlPath = preg_replace('/%5B[0-9]+%5D/simU', '', $urlPath);
+	$ret          = $this->exec($cleanUrlPath, null);
 
         $this->log->addInfo("Result=\n".$ret);
 

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -34,8 +34,10 @@ class IssueService extends \JiraRestApi\JiraClient
         $issueObject = ($issueObject) ? $issueObject : new Issue();
 
         $queryParam = '?'.http_build_query($paramArray);
-
-        $ret = $this->exec($this->uri.'/'.$issueIdOrKey.$queryParam, null);
+        
+		$urlPath      = $this->uri . '/' . $issueIdOrKey . $queryParam;
+		$cleanUrlPath = preg_replace('/%5B[0-9]+%5D/simU', '', $urlPath);
+		$ret          = $this->exec($cleanUrlPath, null);
 
         $this->log->addInfo("Result=\n".$ret);
 


### PR DESCRIPTION
there is a bug when you create a url from a multidimensional 'paramArray'

url path without fix (and in this case the query does not work correctly)
```
/issue/TEST-11157?fields%5B0%5D=-attachment&fields%5B1%5D=-comment&expand%5B0%5D=changelog
```
url path with fix (all correctly)
```
/issue/RR-11157?fields=-attachment&fields=-comment&expand=changelog
```