### PR TITLE
Fix for another curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); 

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -279,7 +279,10 @@ class JiraClient
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->getConfiguration()->isCurlOptSslVerifyHost());
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->getConfiguration()->isCurlOptSslVerifyPeer());
 
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        // curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); cannot be activated when an open_basedir is set
+        if (!function_exists('ini_get') || !ini_get('open_basedir')){
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        }
         curl_setopt($ch, CURLOPT_HTTPHEADER,
             array(
                 'Accept: */*',


### PR DESCRIPTION
Fix for another curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); cannot be activated when an open_basedir is set