### PR TITLE
Added custom Jira API URI setter to JiraClient

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -424,7 +424,7 @@ end:
         return $this->configuration;
     }
 
-     /**
+    /**
      * Set a custom Jira API URI for the request.
      *
      * @param string $api_uri

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -423,4 +423,14 @@ end:
     {
         return $this->configuration;
     }
+
+     /**
+     * Set a custom Jira API URI for the request.
+     *
+     * @param string $api_uri
+     */
+    public function setAPIUri($api_uri)
+    {
+        $this->api_uri = $api_uri;
+    }
 }


### PR DESCRIPTION
By adding this small and simple functionality, the library will be able to make requests to '/rest/agile/1.0' for example, enabling it to get boards, get sprints and such.