### PR TITLE
Support expand attribute in GetAllProjects

### DIFF
--- a/src/Project/ProjectService.php
+++ b/src/Project/ProjectService.php
@@ -13,13 +13,14 @@ class ProjectService extends \JiraRestApi\JiraClient
     /**
      * get all project list.
      *
+     * @param array $paramArray
      * @throws \JiraRestApi\JiraException
      *
      * @return Project[] array of Project class
      */
-    public function getAllProjects()
+    public function getAllProjects($paramArray = [])
     {
-        $ret = $this->exec($this->uri, null);
+        $ret = $this->exec($this->uri.$this->toHttpQueryParameter($paramArray), null);
 
         $prjs = $this->json_mapper->mapArray(
             json_decode($ret, false), new \ArrayObject(), '\JiraRestApi\Project\Project'

--- a/src/Project/ProjectService.php
+++ b/src/Project/ProjectService.php
@@ -14,6 +14,7 @@ class ProjectService extends \JiraRestApi\JiraClient
      * get all project list.
      *
      * @param array $paramArray
+     *
      * @throws \JiraRestApi\JiraException
      *
      * @return Project[] array of Project class


### PR DESCRIPTION
Before this commit, getAllProjects doesn't return some project properties [(reference)](https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-project-get). So if you need the description you have to use the getProject function for every project.

Now, with this change you can use the expand query parameter to ask for the following information:

*    description - description of the project.
*   projectKeys - all project keys associated with the project.
*    lead - project lead. Note, that project lead role is different from project administrator one.
*    issueTypes - issue types associated with the project.
*    url - a URL associated with the project.

The following code is an example of use:
``$this->getProjectService()->getAllProjects(['expand'=>['description']]);``
