### PR TITLE
Fix issue when reporter is null

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -20,7 +20,7 @@ class IssueField implements \JsonSerializable
     /** @var IssueType */
     public $issuetype;
 
-    /** @var Reporter */
+    /** @var Reporter|null */
     public $reporter;
 
     /** @var \DateTime */


### PR DESCRIPTION
 In some situations the reporter can be null but a JSON mapping exception is thrown when it does.