### PR TITLE
Use full namespaces in doc blocks, for the json mapper.

### DIFF
--- a/src/Issue/Attachment.php
+++ b/src/Issue/Attachment.php
@@ -13,7 +13,7 @@ class Attachment implements \JsonSerializable
     /* @var string */
     public $filename;
 
-    /* @var Reporter */
+    /* @var \JiraRestApi\Issue\Reporter */
     public $author;
 
     /* @var \DateTime */

--- a/src/Issue/ChangeLog.php
+++ b/src/Issue/ChangeLog.php
@@ -18,7 +18,7 @@ class ChangeLog implements \JsonSerializable
     /** @var int */
     public $total;
 
-    /** @var History[]|null */
+    /** @var \JiraRestApi\Issue\History[]|null */
     public $histories;
 
     public function jsonSerialize()

--- a/src/Issue/Comment.php
+++ b/src/Issue/Comment.php
@@ -10,13 +10,13 @@ class Comment implements \JsonSerializable
     /** @var string */
     public $id;
 
-    /** @var Reporter */
+    /** @var \JiraRestApi\Issue\Reporter */
     public $author;
 
     /** @var string */
     public $body;
 
-    /** @var Reporter */
+    /** @var \JiraRestApi\Issue\Reporter */
     public $updateAuthor;
 
     /** @var \DateTime */
@@ -25,7 +25,7 @@ class Comment implements \JsonSerializable
     /** @var \DateTime */
     public $updated;
 
-    /** @var Visibility */
+    /** @var \JiraRestApi\Issue\Visibility */
     public $visibility;
 
     public function setBody($body)

--- a/src/Issue/Comments.php
+++ b/src/Issue/Comments.php
@@ -13,7 +13,7 @@ class Comments implements \JsonSerializable
     /** @var int */
     public $total;
 
-    /** @var Comment[] */
+    /** @var \JiraRestApi\Issue\Comment[] */
     public $comments;
 
     public function jsonSerialize()

--- a/src/Issue/History.php
+++ b/src/Issue/History.php
@@ -12,7 +12,7 @@ class History implements \JsonSerializable
     /** @var int */
     public $id;
 
-    /** @var Reporter */
+    /** @var \JiraRestApi\Issue\Reporter */
     public $author;
 
     /** @var string */

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -20,7 +20,7 @@ class Issue implements \JsonSerializable
     /** @var string */
     public $key;
 
-    /** @var IssueField */
+    /** @var \JiraRestApi\Issue\IssueField */
     public $fields;
 
     /** @var array|null */
@@ -41,7 +41,7 @@ class Issue implements \JsonSerializable
     /** @var array|null */
     public $editmeta;
 
-    /** @var ChangeLog|null */
+    /** @var \JiraRestApi\Issue\ChangeLog|null */
     public $changelog;
 
     public function jsonSerialize()

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -32,7 +32,7 @@ class IssueField implements \JsonSerializable
     /** @var string|null */
     public $description;
 
-    /** @var Priority|null */
+    /** @var \JiraRestApi\Issue\Priority|null */
     public $priority;
 
     /** @var \JiraRestApi\Issue\IssueStatus */

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -50,7 +50,7 @@ class IssueField implements \JsonSerializable
     /** @var \JiraRestApi\Issue\Component[] */
     public $components;
 
-    /** @var Comments */
+    /** @var \JiraRestApi\Issue\Comments */
     public $comment;
 
     /** @var object */

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -14,10 +14,10 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $progress;
 
-    /** @var TimeTracking */
+    /** @var \JiraRestApi\Issue\TimeTracking */
     public $timeTracking;
 
-    /** @var IssueType */
+    /** @var \JiraRestApi\Issue\IssueType */
     public $issuetype;
 
     /** @var Reporter|null */
@@ -35,7 +35,7 @@ class IssueField implements \JsonSerializable
     /** @var Priority|null */
     public $priority;
 
-    /** @var IssueStatus */
+    /** @var \JiraRestApi\Issue\IssueStatus */
     public $status;
 
     /** @var array */
@@ -62,7 +62,7 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $fixVersions;
 
-    /** @var Reporter|null */
+    /** @var \JiraRestApi\Issue\Reporter|null */
     public $creator;
 
     /** @var object|null */
@@ -71,7 +71,7 @@ class IssueField implements \JsonSerializable
     /** @var object|null */
     public $worklog;
 
-    /** @var Reporter|null */
+    /** @var \JiraRestApi\Issue\Reporter|null */
     public $assignee;
 
     /** @var \JiraRestApi\Issue\Version[] */
@@ -98,7 +98,7 @@ class IssueField implements \JsonSerializable
     /** @var array */
     public $issuelinks;
 
-    /** @var Issue[] */
+    /** @var \JiraRestApi\Issue\Issue[] */
     public $subtasks;
 
     /** @var int */
@@ -122,7 +122,7 @@ class IssueField implements \JsonSerializable
     /** @var array|null */
     public $customFields;
 
-    /** @var SecurityScheme|null */
+    /** @var \JiraRestApi\Issue\SecurityScheme|null */
     public $security;
 
     public function __construct($updateIssue = false)

--- a/src/Issue/IssueSearchResult.php
+++ b/src/Issue/IssueSearchResult.php
@@ -34,7 +34,7 @@ class IssueSearchResult
     public $total;
 
     /**
-     * @var Issue[]
+     * @var \JiraRestApi\Issue\Issue[]
      */
     public $issues;
 

--- a/src/Issue/IssueStatus.php
+++ b/src/Issue/IssueStatus.php
@@ -19,7 +19,7 @@ class IssueStatus implements \JsonSerializable
     /* @var string */
     public $name;
 
-    /* @var Statuscategory */
+    /* @var \JiraRestApi\Issue\Statuscategory */
     public $statuscategory;
 
     public function jsonSerialize()

--- a/src/Issue/IssueType.php
+++ b/src/Issue/IssueType.php
@@ -22,7 +22,7 @@ class IssueType implements \JsonSerializable
     /** @var bool */
     public $subtask;
 
-    /** @var IssueStatus[] */
+    /** @var \JiraRestApi\Issue\IssueStatus[] */
     public $statuses;
 
     public function jsonSerialize()

--- a/src/Issue/RemoteIssueLink.php
+++ b/src/Issue/RemoteIssueLink.php
@@ -19,7 +19,7 @@ class RemoteIssueLink implements \JsonSerializable
     /** @var string|null */
     public $relationship;
 
-    /** @var RemoteIssueLinkObject|null */
+    /** @var \JiraRestApi\Issue\RemoteIssueLinkObject|null */
     public $object;
 
     public function jsonSerialize()

--- a/src/Issue/Transition.php
+++ b/src/Issue/Transition.php
@@ -13,13 +13,13 @@ class Transition implements \JsonSerializable
     /** @var string */
     public $name;
 
-    /** @var TransitionTo */
+    /** @var \JiraRestApi\Issue\TransitionTo */
     public $to;
 
     /** @var array */
     public $fields;
 
-    /** @var IssueField */
+    /** @var \JiraRestApi\Issue\IssueField */
     public $issueFields;
 
     /** @var array */


### PR DESCRIPTION
Hello,

First of all, thank you for this package. We use it at work, but we have run into a problem that this PR will fix.
In our project we use 2 loaders, 1 is the composer's autoloader and the other one is the yii 1.1 framework's autoloader. Now the issue is that when jsonmapper, tries to instantiate a class from the json response, looks at the docblocks for a class with the name e.g ChangeLog, but it can not find the class using the composer's autoloader. Then (in our project only) is the turn of the yii autoloader to look for the class, which is also unable to locate it and an exception is thrown.

In most projects this wont be an issue because they will use only the composer's autoloader which will fail the first time to locate the class but it will locate it in another pass it will do.

Our fix was to use the full namespaces in the docblocks of the classes, so that the jsonmapper will locate the classes into the first pass, thus there will be no need for our second loader(Yii's autoloader) to run.

I located a number of places where you used non full namespaces and I have updated them all to the full namespaces. Now let me be clear, this is a very specific issue in our use case and I do not think it will happen to any other project, even at the [jsonmapper](https://github.com/cweiske/jsonmapper#supported-type-names) they say that you can use full or non-full namespaces. That being said I do not think it hurts to be specific about the classes that are going to be instantiated. Finally we will gain a minor performance boost because as I have mentioned the classes will be located at the first pass.

Thank you