### PR TITLE
Add configurable CURLOPT_USERAGENT

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["jira", "rest", "jira-php", "jira-rest"],
     "require": {
         "php": ">=5.5.9",
+        "ext-curl": "*",
         "netresearch/jsonmapper": "~0.11|^1.0",
         "monolog/monolog": "~1.12",
         "vlucas/phpdotenv": "~1.0|~2.0"

--- a/src/Configuration/AbstractConfiguration.php
+++ b/src/Configuration/AbstractConfiguration.php
@@ -57,6 +57,13 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     protected $curlOptSslVerifyPeer;
 
     /**
+     * Curl option CURLOPT_USERAGENT
+     *
+     * @var string
+     */
+    protected $curlOptUserAgent;
+
+    /**
      * Curl options CURLOPT_VERBOSE.
      *
      * @var bool
@@ -139,6 +146,16 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     public function isCurlOptVerbose()
     {
         return $this->curlOptVerbose;
+    }
+
+    /**
+     * Get curl option CURLOPT_USERAGENT
+     *
+     * @return string
+     */
+    public function getCurlOptUserAgent()
+    {
+        return $this->curlOptUserAgent;
     }
 
     /**

--- a/src/Configuration/AbstractConfiguration.php
+++ b/src/Configuration/AbstractConfiguration.php
@@ -57,7 +57,7 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     protected $curlOptSslVerifyPeer;
 
     /**
-     * Curl option CURLOPT_USERAGENT
+     * Curl option CURLOPT_USERAGENT.
      *
      * @var string
      */
@@ -149,7 +149,7 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     }
 
     /**
-     * Get curl option CURLOPT_USERAGENT
+     * Get curl option CURLOPT_USERAGENT.
      *
      * @return string
      */

--- a/src/Configuration/ArrayConfiguration.php
+++ b/src/Configuration/ArrayConfiguration.php
@@ -23,6 +23,7 @@ class ArrayConfiguration extends AbstractConfiguration
         $this->curlOptSslVerifyHost = false;
         $this->curlOptSslVerifyPeer = false;
         $this->curlOptVerbose = false;
+        $this->curlOptUserAgent = '';
         $this->cookieAuthEnabled = false;
 
         foreach ($configuration as $key => $value) {

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -70,7 +70,7 @@ interface ConfigurationInterface
     public function isCurlOptVerbose();
 
     /**
-     * Get curl option CURLOPT_USERAGENT
+     * Get curl option CURLOPT_USERAGENT.
      *
      * @return string
      */

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -70,6 +70,13 @@ interface ConfigurationInterface
     public function isCurlOptVerbose();
 
     /**
+     * Get curl option CURLOPT_USERAGENT
+     *
+     * @return string
+     */
+    public function getCurlOptUserAgent();
+
+    /**
      * HTTP header 'Authorization: Bearer {token}' for OAuth.
      *
      * @return string

--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -38,6 +38,7 @@ class DotEnvConfiguration extends AbstractConfiguration
         $this->jiraLogLevel = $this->env('JIRA_LOG_LEVEL', 'WARNING');
         $this->curlOptSslVerifyHost = $this->env('CURLOPT_SSL_VERIFYHOST', false);
         $this->curlOptSslVerifyPeer = $this->env('CURLOPT_SSL_VERIFYPEER', false);
+        $this->curlOptUserAgent = $this->env('CURLOPT_USERAGENT', '');
         $this->curlOptVerbose = $this->env('CURLOPT_VERBOSE', false);
     }
 

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -202,6 +202,7 @@ class JiraClient
 
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->getConfiguration()->isCurlOptSslVerifyHost());
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->getConfiguration()->isCurlOptSslVerifyPeer());
+        curl_setopt($ch, CURLOPT_USERAGENT, $this->getConfiguration()->getCurlOptUserAgent());
 
         // curl_setopt(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set
         if (!function_exists('ini_get') || !ini_get('open_basedir')) {


### PR DESCRIPTION
Hi,

For some unknown reason all requests return status code 200 but empty body (Jira v7.8.2).
The problem was that request doesn't contain curl user-agent.
I didn't find easy way to make all curl options configurable, so I just add this parameter to configs.

Off-topic: Is there any reason folder "php-jira-rest-client/src/**sprint**/" to be lower case?
