### PR TITLE
Fixed SprintService so sprint can be pulled by ID.

### DIFF
--- a/src/Sprint/SprintService.php
+++ b/src/Sprint/SprintService.php
@@ -43,16 +43,14 @@ class SprintService extends JiraClient
      *
      * @return object
      */
-    public function getSprint($sprintObject = null)
+    public function getSprint($sprintId)
     {
-        $sprintObject = ($sprintObject) ? $sprintObject : new Sprint();
-
-        $ret = $this->exec($this->uri.'/$sprintId', null);
+        $ret = $this->exec($this->uri.'/'.$sprintId, null);
 
         $this->log->addInfo("Result=\n".$ret);
 
         return $sprint = $this->json_mapper->map(
-            json_decode($ret), $sprintObject
+            json_decode($ret), new Sprint()
         );
     }
 }


### PR DESCRIPTION
This is a fix for Attempt to Pull by Sprint ID calls incorrect endpoint #190, 

Instead of getSprint method requiring SprintObject updated getSprint method of SprintService to need a sprintID, so sprint works like other get methods, like getProject in ProjectService.
