### PR TITLE
add curl compression

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -204,6 +204,7 @@ class JiraClient
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         }
 
+        curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLOPT_HTTPHEADER,
             ['Accept: */*', 'Content-Type: application/json', 'X-Atlassian-Token: no-check']);
 


### PR DESCRIPTION
add `CURLOPT_ENCODING` to curl.

see http://php.net/curl_setopt
```
The contents of the "Accept-Encoding: " header. This enables decoding of the response.
Supported encodings are "identity", "deflate", and "gzip".
If an empty string, "", is set, a header containing all supported encoding types is sent. 
```