### PR TITLE
Use DateTimeInterface instead of DateTime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": ">=5.5.9",
         "ext-curl": "*",
+        "ext-json": "*",
         "netresearch/jsonmapper": "~0.11|^1.0",
         "monolog/monolog": "~1.12",
         "vlucas/phpdotenv": "~1.0|~2.0"

--- a/src/Issue/Attachment.php
+++ b/src/Issue/Attachment.php
@@ -16,7 +16,7 @@ class Attachment implements \JsonSerializable
     /* @var \JiraRestApi\Issue\Reporter */
     public $author;
 
-    /* @var \DateTime */
+    /* @var \DateTimeInterface */
     public $created;
 
     /* @var int */

--- a/src/Issue/Comment.php
+++ b/src/Issue/Comment.php
@@ -21,10 +21,10 @@ class Comment implements \JsonSerializable
     /** @var \JiraRestApi\Issue\Reporter */
     public $updateAuthor;
 
-    /** @var \DateTime */
+    /** @var \DateTimeInterface */
     public $created;
 
-    /** @var \DateTime */
+    /** @var \DateTimeInterface */
     public $updated;
 
     /** @var \JiraRestApi\Issue\Visibility */

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -23,10 +23,10 @@ class IssueField implements \JsonSerializable
     /** @var Reporter|null */
     public $reporter;
 
-    /** @var \DateTime */
+    /** @var \DateTimeInterface */
     public $created;
 
-    /** @var \DateTime */
+    /** @var \DateTimeInterface */
     public $updated;
 
     /** @var string|null */
@@ -92,7 +92,7 @@ class IssueField implements \JsonSerializable
     /** @var string|null */
     public $resolutiondate;
 
-    /** @var \DateTime|null */
+    /** @var \DateTimeInterface|null */
     public $duedate;
 
     /** @var array */
@@ -412,8 +412,8 @@ class IssueField implements \JsonSerializable
     /**
      * set issue's due date.
      *
-     * @param string|\DateTime|null $duedate due date string or DateTime object
-     * @param string                $format  datetime string format.
+     * @param string|\DateTimeInterface|null $duedate due date string or DateTimeInterface object
+     * @param string                         $format  datetime string format.
      *
      * @return $this
      */
@@ -421,7 +421,7 @@ class IssueField implements \JsonSerializable
     {
         if (is_string($duedate)) {
             $this->duedate = $duedate;
-        } elseif ($duedate instanceof \DateTime) {
+        } elseif ($duedate instanceof \DateTimeInterface) {
             $this->duedate = $duedate->format($format);
         } else {
             $this->duedate = null;

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -412,8 +412,8 @@ class IssueField implements \JsonSerializable
     /**
      * set issue's due date.
      *
-     * @param \DateTime|null $duedate due date string or DateTime object
-     * @param string         $format  datetime string format.
+     * @param string|\DateTime|null $duedate due date string or DateTime object
+     * @param string                $format  datetime string format.
      *
      * @return $this
      */

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -22,7 +22,7 @@ class Version implements \JsonSerializable
     /** @var bool */
     public $released;
 
-    /** @var \DateTime|null */
+    /** @var \DateTimeInterface|null */
     public $releaseDate;
 
     /** @var bool */

--- a/src/Issue/Worklog.php
+++ b/src/Issue/Worklog.php
@@ -87,10 +87,12 @@ class Worklog
         return $this;
     }
 
+    // Note that in the docblock below, you cannot replace `mixed` by `\DateTimeInterface|string` because JsonMapper doesn't support that,
+    // see <https://github.com/cweiske/jsonmapper/issues/64#issuecomment-269545585>.
     /**
      * Function to set start time of worklog.
      *
-     * @param string|\DateTimeInterface $started started time value  e.g. -  new \DateTime("2016-03-17 11:15:34") or "2016-03-17 11:15:34"
+     * @param mixed $started started time value(\DateTimeInterface|string)  e.g. -  new \DateTime("2016-03-17 11:15:34") or "2016-03-17 11:15:34"
      *
      * @throws JiraException
      *

--- a/src/Issue/Worklog.php
+++ b/src/Issue/Worklog.php
@@ -90,7 +90,7 @@ class Worklog
     /**
      * Function to set start time of worklog.
      *
-     * @param mixed $started started time value(\DateTime|string)  e.g. -  new DateTime("2016-03-17 11:15:34") or "2016-03-17 11:15:34"
+     * @param string|\DateTimeInterface $started started time value  e.g. -  new \DateTime("2016-03-17 11:15:34") or "2016-03-17 11:15:34"
      *
      * @throws JiraException
      *
@@ -100,10 +100,10 @@ class Worklog
     {
         if (is_string($started)) {
             $dt = new \DateTime($started);
-        } elseif ($started instanceof \DateTime) {
+        } elseif ($started instanceof \DateTimeInterface) {
             $dt = $started;
         } else {
-            throw new JiraException('field only accept date string or DateTime class.'.get_class($started));
+            throw new JiraException('field only accept date string or DateTimeInterface object.'.get_class($started));
         }
 
         // workround micro second
@@ -115,7 +115,7 @@ class Worklog
     /**
      * Function to set start time of worklog.
      *
-     * @param \DateTime $started e.g. -  new DateTime("2014-04-05 16:00:00")
+     * @param \DateTimeInterface $started e.g. -  new \DateTime("2014-04-05 16:00:00")
      *
      * @return Worklog
      */

--- a/src/Issue/Worklog.php
+++ b/src/Issue/Worklog.php
@@ -89,6 +89,7 @@ class Worklog
 
     // Note that in the docblock below, you cannot replace `mixed` by `\DateTimeInterface|string` because JsonMapper doesn't support that,
     // see <https://github.com/cweiske/jsonmapper/issues/64#issuecomment-269545585>.
+
     /**
      * Function to set start time of worklog.
      *

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -82,7 +82,7 @@ class JiraClient
         $this->json_mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
 
         // Properties that are annotated with `@var \DateTimeInterface` should result in \DateTime objects being created.
-        $this->json_mapper->classMap[\DateTimeInterface::class] = \DateTime::class;
+        $this->json_mapper->classMap['\\' . \DateTimeInterface::class] = \DateTime::class;
 
         // create logger
         if ($logger) {

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -81,6 +81,9 @@ class JiraClient
         // Fix "\JiraRestApi\JsonMapperHelper::class" syntax error, unexpected 'class' (T_CLASS), expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$'
         $this->json_mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
 
+        // Properties that are annotated with `@var \DateTimeInterface` should result in \DateTime objects being created.
+        $this->json_mapper->classMap[\DateTimeInterface::class] = \DateTime::class;
+
         // create logger
         if ($logger) {
             $this->log = $logger;

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -82,7 +82,7 @@ class JiraClient
         $this->json_mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
 
         // Properties that are annotated with `@var \DateTimeInterface` should result in \DateTime objects being created.
-        $this->json_mapper->classMap['\\' . \DateTimeInterface::class] = \DateTime::class;
+        $this->json_mapper->classMap['\\'.\DateTimeInterface::class] = \DateTime::class;
 
         // create logger
         if ($logger) {

--- a/src/Version/VersionService.php
+++ b/src/Version/VersionService.php
@@ -24,7 +24,7 @@ class VersionService extends \JiraRestApi\JiraClient
      */
     public function create($version)
     {
-        if ($version->releaseDate instanceof \DateTime) {
+        if ($version->releaseDate instanceof \DateTimeInterface) {
             $version->releaseDate = $version->releaseDate->format('Y-m-d');
         }
         $data = json_encode($version);
@@ -88,7 +88,7 @@ class VersionService extends \JiraRestApi\JiraClient
             throw new JiraException($version->id.' is not a valid version id.');
         }
 
-        if ($version->releaseDate instanceof \DateTime) {
+        if ($version->releaseDate instanceof \DateTimeInterface) {
             $version->releaseDate = $version->releaseDate->format('Y-m-d');
         }
 

--- a/tests/AssigneeTest.php
+++ b/tests/AssigneeTest.php
@@ -15,7 +15,7 @@ class AssigneeTest extends PHPUnit_Framework_TestCase
     {
         $this->mapper = new JsonMapper();
         $this->mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
-        $this->mapper->classMap[\DateTimeInterface::class] = \DateTime::class;
+        $this->mapper->classMap['\\' . \DateTimeInterface::class] = \DateTime::class;
     }
 
     public function tearDown()

--- a/tests/AssigneeTest.php
+++ b/tests/AssigneeTest.php
@@ -15,6 +15,7 @@ class AssigneeTest extends PHPUnit_Framework_TestCase
     {
         $this->mapper = new JsonMapper();
         $this->mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
+        $this->mapper->classMap[\DateTimeInterface::class] = \DateTime::class;
     }
 
     public function tearDown()

--- a/tests/AssigneeTest.php
+++ b/tests/AssigneeTest.php
@@ -15,7 +15,7 @@ class AssigneeTest extends PHPUnit_Framework_TestCase
     {
         $this->mapper = new JsonMapper();
         $this->mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
-        $this->mapper->classMap['\\' . \DateTimeInterface::class] = \DateTime::class;
+        $this->mapper->classMap['\\'.\DateTimeInterface::class] = \DateTime::class;
     }
 
     public function tearDown()

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -17,6 +17,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     {
         $this->mapper = new JsonMapper();
         $this->mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
+        $this->mapper->classMap[\DateTimeInterface::class] = \DateTime::class;
     }
 
     public function tearDown()

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -17,7 +17,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     {
         $this->mapper = new JsonMapper();
         $this->mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
-        $this->mapper->classMap[\DateTimeInterface::class] = \DateTime::class;
+        $this->mapper->classMap['\\' . \DateTimeInterface::class] = \DateTime::class;
     }
 
     public function tearDown()

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -17,7 +17,7 @@ class MapperTest extends PHPUnit_Framework_TestCase
     {
         $this->mapper = new JsonMapper();
         $this->mapper->undefinedPropertyHandler = [new \JiraRestApi\JsonMapperHelper(), 'setUndefinedProperty'];
-        $this->mapper->classMap['\\' . \DateTimeInterface::class] = \DateTime::class;
+        $this->mapper->classMap['\\'.\DateTimeInterface::class] = \DateTime::class;
     }
 
     public function tearDown()


### PR DESCRIPTION
This is the PR for #211. After merging it, `\DateTimeImmutable` can be supplied as input in all places where only `\DateTime` was supported before.

Example:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

$wl = new \JiraRestApi\Issue\Worklog();
$wl->setStartedDateTime(new DateTimeImmutable());
var_dump($wl);
```

It's using JsonMapper's `classMap` feature to tell it that instead of trying to create `\DateTimeInterface` objects (which won't work, since it's an interface), it should create `\DateTime` objects instead. This also means that when JIRA Rest Client instantiates an object from a string, it will use `\DateTime` as before and therefore not break existing code using this library.

This PR currently includes a workaround for a quirk in JsonMapper, cweiske/jsonmapper#111. Feel free to keep the PR unmerged until this is resolved.

Oh, and a little unrelated, but I've also added the obvious requirement of `ext-json` to `composer.json`.