### PR TITLE
Add capability to retrieve all board sprints

### DIFF
--- a/src/Board/BoardService.php
+++ b/src/Board/BoardService.php
@@ -4,6 +4,7 @@ namespace JiraRestApi\Board;
 
 use JiraRestApi\Configuration\ConfigurationInterface;
 use JiraRestApi\Issue\Issue;
+use JiraRestApi\Sprint\Sprint;
 use Psr\Log\LoggerInterface;
 
 class BoardService extends \JiraRestApi\JiraClient
@@ -48,10 +49,20 @@ class BoardService extends \JiraRestApi\JiraClient
     public function getBoardIssues($id, $paramArray = [])
     {
         $json = $this->exec($this->uri.'/'.$id.'/issue'.$this->toHttpQueryParameter($paramArray), null);
-        $board = $this->json_mapper->mapArray(
+        $issues = $this->json_mapper->mapArray(
             json_decode($json)->issues, new \ArrayObject(), Issue::class
         );
 
-        return $board;
+        return $issues;
+    }
+
+    public function getBoardSprints($boardId, $paramArray = [])
+    {
+        $json = $this->exec($this->uri . '/' . $boardId . '/sprint' . $this->toHttpQueryParameter($paramArray), null);
+        $sprints = $this->json_mapper->mapArray(
+            json_decode($json)->values, new \ArrayObject(), Sprint::class
+        );
+
+        return $sprints;
     }
 }

--- a/src/Board/BoardService.php
+++ b/src/Board/BoardService.php
@@ -58,9 +58,11 @@ class BoardService extends \JiraRestApi\JiraClient
 
     public function getBoardSprints($boardId, $paramArray = [])
     {
-        $json = $this->exec($this->uri . '/' . $boardId . '/sprint' . $this->toHttpQueryParameter($paramArray), null);
+        $json = $this->exec($this->uri.'/'.$boardId.'/sprint'.$this->toHttpQueryParameter($paramArray), null);
         $sprints = $this->json_mapper->mapArray(
-            json_decode($json)->values, new \ArrayObject(), Sprint::class
+            json_decode($json)->values,
+            new \ArrayObject(),
+            Sprint::class
         );
 
         return $sprints;


### PR DESCRIPTION
Added a method to retrieve all board sprints.
Didn't add tests, since some of the board are hardcoded in your Jira instance so there's no good way for me to test this, except using on my own code, which I'm doing