### PR TITLE
return version instead of array of unknown project type

### DIFF
--- a/src/Version/VersionService.php
+++ b/src/Version/VersionService.php
@@ -34,7 +34,8 @@ class VersionService extends \JiraRestApi\JiraClient
         $ret = $this->exec($this->uri, $data, 'POST');
 
         return $this->json_mapper->map(
-            json_decode($ret), new Version()
+            json_decode($ret),
+            new Version()
         );
     }
 
@@ -66,7 +67,8 @@ class VersionService extends \JiraRestApi\JiraClient
         $this->log->info('Result='.$ret);
 
         return $this->json_mapper->map(
-            json_decode($ret), new Version()
+            json_decode($ret),
+            new Version()
         );
     }
 
@@ -96,7 +98,8 @@ class VersionService extends \JiraRestApi\JiraClient
         $ret = $this->exec($this->uri.'/'.$version->id, $data, 'PUT');
 
         return $this->json_mapper->map(
-            json_decode($ret), new Version()
+            json_decode($ret),
+            new Version()
         );
     }
 

--- a/src/Version/VersionService.php
+++ b/src/Version/VersionService.php
@@ -65,12 +65,9 @@ class VersionService extends \JiraRestApi\JiraClient
 
         $this->log->info('Result='.$ret);
 
-        $json = json_decode($ret);
-        $results = array_map(function ($elem) {
-            return $this->json_mapper->map($elem, new ProjectType());
-        }, $json);
-
-        return $results;
+        return $this->json_mapper->map(
+            json_decode($ret), new Version()
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/lesstif/php-jira-rest-client/issues/259

There is no case where the jira version request returns an array as far as i know.