### PR TITLE
Return $this when calling setParentKeyOrId()

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -389,6 +389,8 @@ class IssueField implements \JsonSerializable
         } elseif (is_string($keyOrId)) {
             $this->parent['key'] = $keyOrId;
         }
+
+        return $this;
     }
 
     public function setParent(Issue $parent)


### PR DESCRIPTION
When chaining method calls `setParentKeyOrId()` returns `null` and therefore breaks the chain.