### PR TITLE
fixed addComment/updateComment

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -225,7 +225,7 @@ class IssueService extends \JiraRestApi\JiraClient
     {
         $this->log->info("addComment=\n");
 
-        $data = json_encode($comment);
+        $data = json_encode(['body' => $comment]);
 
         $ret = $this->exec($this->uri."/$issueIdOrKey/comment", $data);
 
@@ -253,7 +253,7 @@ class IssueService extends \JiraRestApi\JiraClient
     {
         $this->log->info("updateComment=\n");
 
-        $data = json_encode($comment);
+        $data = json_encode(['body' => $comment]);
 
         $ret = $this->exec($this->uri."/$issueIdOrKey/comment/$id", $data, 'PUT');
 


### PR DESCRIPTION
the comment-text is expected as a "body" post/put-value, see https://community.atlassian.com/t5/Answers-Developer-Questions/How-to-add-comments-using-rest-api/qaq-p/571351#M109009

without this changes jira throws an exception:
```
Fatal error: Uncaught JiraRestApi\JiraException: CURL HTTP Request Failed: Status Code : 400, URL:https://jira.complex.local/rest/api/2/issue/VERTRIEB-216/comment
Error Message : {"errorMessages":["Can not instantiate value of type [simple type, class com.atlassian.jira.issue.fields.rest.json.beans.CommentJsonBean] from JSON String; no single-String constructor/factory method"]} in C:\dvl\Zend\DefaultWorkspace13\jira-rest\vendor\lesstif\php-j
ira-rest-client\src\JiraClient.php:264
Stack trace:
#0 C:\dvl\Zend\DefaultWorkspace13\jira-rest\vendor\lesstif\php-jira-rest-client\src\Issue\IssueService.php(230): JiraRestApi\JiraClient->exec('/issue/VERTRIEB...', '"hallo markus 1...')
#1 C:\dvl\Zend\DefaultWorkspace13\jira-rest\find-issues.php(16): JiraRestApi\Issue\IssueService->addComment('VERTRIEB-216', 'hallo markus 12...')
#2 {main}
  thrown in C:\dvl\Zend\DefaultWorkspace13\jira-rest\vendor\lesstif\php-jira-rest-client\src\JiraClient.php on line 264
```

I tested the changes locally. it works as expected.