### PR TITLE
add optional paramArray parameter to IssueService getTransition

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -422,14 +422,17 @@ class IssueService extends \JiraRestApi\JiraClient
      * Get a list of the transitions possible for this issue by the current user, along with fields that are required and their types.
      *
      * @param string|int $issueIdOrKey Issue id or key
+     * @param array      $paramArray   Query Parameter key-value Array.
      *
      * @throws JiraException
      *
      * @return Transition[] array of Transition class
      */
-    public function getTransition($issueIdOrKey)
+    public function getTransition($issueIdOrKey, $paramArray = [])
     {
-        $ret = $this->exec($this->uri."/$issueIdOrKey/transitions");
+        $queryParam = '?'.http_build_query($paramArray);
+        
+        $ret = $this->exec($this->uri."/$issueIdOrKey/transitions".$queryParam);
 
         $this->log->debug('getTransitions result='.var_export($ret, true));
 


### PR DESCRIPTION
When requesting transitions, if you want to apply a transition you might need to query the fields it has, which are not included when you do the request without additional parameters. 

With this change, we can get them like this:

`$issueService->getTransition("ISS-001", 
            ["expand" => "transitions.fields"]
        );`