### PR TITLE
setReporterAccountId (conforms to new API rules)

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -230,6 +230,24 @@ class IssueField implements \JsonSerializable
     }
 
     /**
+     * set issue reporter accountId.
+     *
+     * @param string $accountId
+     *
+     * @return $this
+     */
+    public function setReporterAccountId($accountId)
+    {
+        if (is_null($this->reporter)) {
+            $this->reporter = new Reporter();
+        }
+
+        $this->reporter->accountId = $accountId;
+
+        return $this;
+    }
+
+    /**
      * set issue assignee name.
      *
      * @param string $name


### PR DESCRIPTION
Jira's API is deprecating functionalities that tamper with usernames and will only allow the use of accountId. This includes the creation of new issues and changing/setting the reporter by name.

This allows to set the reporter's accountId, which can circumvent this problem.