### PR TITLE
added deleteWorkflow method to JiraRestApi\Issue\IssueService

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -700,6 +700,28 @@ class IssueService extends \JiraRestApi\JiraClient
     }
 
     /**
+     * delete worklog.
+     *
+     * @param string|int $issueIdOrKey
+     * @param string|int $worklogId
+     *
+     * @throws JiraException
+     *
+     * @return bool
+     */
+    public function deleteWorklog($issueIdOrKey, $worklogId)
+    {
+        $this->log->info("deleteWorklog=\n");
+
+        $url = $this->uri."/$issueIdOrKey/worklog/$worklogId";
+        $type = 'DELETE';
+
+        $ret = $this->exec($url, null, $type);
+
+        return (bool)$ret;
+    }
+
+    /**
      * Get all priorities.
      *
      * @throws JiraException

--- a/tests/WorkLogTest.php
+++ b/tests/WorkLogTest.php
@@ -91,4 +91,20 @@ class WorkLogTest extends PHPUnit_Framework_TestCase
             $this->assertTrue(false, 'testGetWorkLogById Failed : '.$e->getMessage());
         }
     }
+
+    /**
+     * @depends testUpdateWorkLogInIssue
+     */
+    public function testDeleteWorkLogById($workLogid)
+    {
+        try {
+            $issueService = new IssueService();
+
+            $worklog = $issueService->deleteWorklog($this->issueKey, $workLogid);
+
+            Dumper::dump($worklog);
+        } catch (JiraException $e) {
+            $this->assertTrue(false, 'testDeleteWorkLogById Failed : '.$e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Hi!

First of all, Thank you for great project!

I needed to remove Jira ticket Worklog and I didn't found option to this in current code.
This PR introduces new public deleteWorkflow method right next to editWorklog and addWorklog.
I was not able to figure out how to write test case. I assume I need to fire up local jira service that I'm not willing to do. Please adjust my test case if it fails.. I do not have a way to properly prepare it locally.