### PR TITLE
Improvement of IssueService::getComments method

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -306,7 +306,7 @@ class IssueService extends \JiraRestApi\JiraClient
      * @throws JiraException
      * @throws \JsonMapper_Exception
      *
-     * @return Comment|object Comment class
+     * @return Comments|object Comments class
      */
     public function getComments($issueIdOrKey)
     {
@@ -315,11 +315,11 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($this->uri."/$issueIdOrKey/comment");
 
         $this->log->debug('get comments result='.var_export($ret, true));
-        $comment = $this->json_mapper->map(
-                json_decode($ret), new Comment()
-                );
+        $comments = $this->json_mapper->map(
+            json_decode($ret), new Comments()
+        );
 
-        return $comment;
+        return $comments;
     }
 
     /**

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -169,8 +169,10 @@ class IssueService extends \JiraRestApi\JiraClient
                     array_push($attachArr, $t);
                 }
             } elseif (is_object($ret)) {
-                array_push($attachArr, $this->json_mapper->map(
-                    $ret, new Attachment()
+                array_push($attachArr,
+                    $this->json_mapper->map(
+                        $ret,
+                        new Attachment()
                     )
                 );
             }

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -242,8 +242,8 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->debug('add comment result='.var_export($ret, true));
         $comment = $this->json_mapper->map(
-           json_decode($ret),
-           new Comment()
+            json_decode($ret),
+            new Comment()
         );
 
         return $comment;
@@ -450,9 +450,9 @@ class IssueService extends \JiraRestApi\JiraClient
         $data = json_encode(json_decode($ret)->transitions);
 
         $transitions = $this->json_mapper->mapArray(
-           json_decode($data),
-           new \ArrayObject(),
-           '\JiraRestApi\Issue\Transition'
+            json_decode($data),
+            new \ArrayObject(),
+            '\JiraRestApi\Issue\Transition'
         );
 
         return $transitions;
@@ -578,8 +578,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->debug("getTimeTracking res=$ret\n");
 
         $issue = $this->json_mapper->map(
-             json_decode($ret),
-             new Issue()
+            json_decode($ret),
+            new Issue()
         );
 
         return $issue->fields->timeTracking;
@@ -682,8 +682,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($url, $data, $type);
 
         $ret_worklog = $this->json_mapper->map(
-           json_decode($ret),
-           new Worklog()
+            json_decode($ret),
+            new Worklog()
         );
 
         return $ret_worklog;
@@ -731,7 +731,9 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec('priority', null);
 
         $priorities = $this->json_mapper->mapArray(
-             json_decode($ret, false), new \ArrayObject(), '\JiraRestApi\Issue\Priority'
+            json_decode($ret, false),
+            new \ArrayObject(),
+            '\JiraRestApi\Issue\Priority'
         );
 
         return $priorities;
@@ -755,8 +757,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->info('Result='.$ret);
 
         $prio = $this->json_mapper->map(
-             json_decode($ret),
-             new Priority()
+            json_decode($ret),
+            new Priority()
         );
 
         return $prio;
@@ -805,7 +807,9 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($url, null);
 
         $watchers = $this->json_mapper->mapArray(
-            json_decode($ret, false)->watchers, new \ArrayObject(), '\JiraRestApi\Issue\Reporter'
+            json_decode($ret, false)->watchers,
+            new \ArrayObject(),
+            '\JiraRestApi\Issue\Reporter'
         );
 
         return $watchers;
@@ -987,7 +991,9 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($full_uri, null);
 
         $rils = $this->json_mapper->mapArray(
-            json_decode($ret, false), new \ArrayObject(), RemoteIssueLink::class
+            json_decode($ret, false),
+            new \ArrayObject(),
+            RemoteIssueLink::class
         );
 
         return $rils;
@@ -1068,7 +1074,9 @@ class IssueService extends \JiraRestApi\JiraClient
         $schemes = json_decode(json_encode($data['issueSecuritySchemes']), false);
 
         $res = $this->json_mapper->mapArray(
-            $schemes, new \ArrayObject(), '\JiraRestApi\Issue\SecurityScheme'
+            $schemes,
+            new \ArrayObject(),
+            '\JiraRestApi\Issue\SecurityScheme'
         );
 
         return $res;

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -170,7 +170,8 @@ class IssueService extends \JiraRestApi\JiraClient
                     array_push($attachArr, $t);
                 }
             } elseif (is_object($ret)) {
-                array_push($attachArr,
+                array_push(
+                    $attachArr,
                     $this->json_mapper->map(
                         $ret,
                         new Attachment()
@@ -319,7 +320,8 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->debug('get comments result='.var_export($ret, true));
         $comments = $this->json_mapper->map(
-            json_decode($ret), new Comments()
+            json_decode($ret),
+            new Comments()
         );
 
         return $comments;

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -18,7 +18,8 @@ class IssueService extends \JiraRestApi\JiraClient
     public function getIssueFromJSON($json)
     {
         $issue = $this->json_mapper->map(
-            $json, new Issue()
+            $json,
+            new Issue()
         );
 
         return $issue;

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -51,7 +51,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->info("Result=\n".$ret);
 
         return $issue = $this->json_mapper->map(
-            json_decode($ret), $issueObject
+            json_decode($ret),
+            $issueObject
         );
     }
 
@@ -163,7 +164,9 @@ class IssueService extends \JiraRestApi\JiraClient
             $ret = json_decode($ret);
             if (is_array($ret)) {
                 $tmpArr = $this->json_mapper->mapArray(
-                    $ret, new \ArrayObject(), '\JiraRestApi\Issue\Attachment'
+                    $ret,
+                    new \ArrayObject(),
+                    '\JiraRestApi\Issue\Attachment'
                 );
 
                 foreach ($tmpArr as $t) {
@@ -239,7 +242,8 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->debug('add comment result='.var_export($ret, true));
         $comment = $this->json_mapper->map(
-           json_decode($ret), new Comment()
+           json_decode($ret),
+           new Comment()
         );
 
         return $comment;
@@ -271,7 +275,8 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->debug('update comment result='.var_export($ret, true));
         $comment = $this->json_mapper->map(
-            json_decode($ret), new Comment()
+            json_decode($ret),
+            new Comment()
         );
 
         return $comment;
@@ -296,8 +301,9 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->debug('get comment result='.var_export($ret, true));
         $comment = $this->json_mapper->map(
-                json_decode($ret), new Comment()
-                );
+            json_decode($ret),
+            new Comment()
+        );
 
         return $comment;
     }
@@ -444,7 +450,9 @@ class IssueService extends \JiraRestApi\JiraClient
         $data = json_encode(json_decode($ret)->transitions);
 
         $transitions = $this->json_mapper->mapArray(
-           json_decode($data), new \ArrayObject(), '\JiraRestApi\Issue\Transition'
+           json_decode($data),
+           new \ArrayObject(),
+           '\JiraRestApi\Issue\Transition'
         );
 
         return $transitions;
@@ -541,11 +549,13 @@ class IssueService extends \JiraRestApi\JiraClient
         $result = null;
         if ($this->isRestApiV3()) {
             $result = $this->json_mapper->map(
-                $json, new IssueSearchResultV3()
+                $json,
+                new IssueSearchResultV3()
             );
         } else {
             $result = $this->json_mapper->map(
-                $json, new IssueSearchResult()
+                $json,
+                new IssueSearchResult()
             );
         }
 
@@ -568,7 +578,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->debug("getTimeTracking res=$ret\n");
 
         $issue = $this->json_mapper->map(
-             json_decode($ret), new Issue()
+             json_decode($ret),
+             new Issue()
         );
 
         return $issue->fields->timeTracking;
@@ -619,7 +630,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($this->uri."/$issueIdOrKey/worklog");
         $this->log->debug("getWorklog res=$ret\n");
         $worklog = $this->json_mapper->map(
-            json_decode($ret), new PaginatedWorklog()
+            json_decode($ret),
+            new PaginatedWorklog()
         );
 
         return $worklog;
@@ -641,7 +653,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($this->uri."/$issueIdOrKey/worklog/$workLogId");
         $this->log->debug("getWorklogById res=$ret\n");
         $worklog = $this->json_mapper->map(
-            json_decode($ret), new Worklog()
+            json_decode($ret),
+            new Worklog()
         );
 
         return $worklog;
@@ -669,7 +682,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($url, $data, $type);
 
         $ret_worklog = $this->json_mapper->map(
-           json_decode($ret), new Worklog()
+           json_decode($ret),
+           new Worklog()
         );
 
         return $ret_worklog;
@@ -698,7 +712,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($url, $data, $type);
 
         $ret_worklog = $this->json_mapper->map(
-            json_decode($ret), new Worklog()
+            json_decode($ret),
+            new Worklog()
         );
 
         return $ret_worklog;
@@ -740,7 +755,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->info('Result='.$ret);
 
         $prio = $this->json_mapper->map(
-             json_decode($ret), new Priority()
+             json_decode($ret),
+             new Priority()
         );
 
         return $prio;
@@ -764,7 +780,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->info('Result='.$ret);
 
         $prio = $this->json_mapper->map(
-            json_decode($ret), new Priority()
+            json_decode($ret),
+            new Priority()
         );
 
         return $prio;
@@ -996,7 +1013,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($full_uri, $data, 'POST');
 
         $res = $this->json_mapper->map(
-            json_decode($ret), new RemoteIssueLink()
+            json_decode($ret),
+            new RemoteIssueLink()
         );
 
         return $res;
@@ -1073,7 +1091,8 @@ class IssueService extends \JiraRestApi\JiraClient
         $ret = $this->exec($url);
 
         $res = $this->json_mapper->map(
-            json_decode($ret), new SecurityScheme()
+            json_decode($ret),
+            new SecurityScheme()
         );
 
         return $res;


### PR DESCRIPTION
Target structure of getComments method supposed to be Comments object, but Comment object is given. We should pass a "Comments" object to the mapper to map fields correctly. So that json fields were mapped to the object of Comments class that has all the necessary fields, such as "total", "comments", "startAt" and "maxResults" and is intended for this. Now all the fields are filling into a Comment object, that is incorrect.