### PR TITLE
implement phpstan for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,9 @@ script:
 matrix:
 #  allow_failures:
 #    - php: 7.5
+  include:
+    - php: 7.1
+        name: phpstan
+        script:
+          - vendor/bin/phpstan analyse
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "phpunit/phpunit": ">=5.7 <6",
         "mockery/mockery": "^0.9.4",
-        "symfony/var-dumper": "~2.8|~3.0"
+        "symfony/var-dumper": "~2.8|~3.0",
+        "phpstan/phpstan": "^0.12.23"
     },
     "license": "Apache-2.0",
     "authors": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,17 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Static method Dotenv\\\\Dotenv\\:\\:create\\(\\) invoked with 1 parameter, 2\\-4 required\\.$#"
+			count: 1
+			path: src/Configuration/DotEnvConfiguration.php
+
+		-
+			message: "#^Class Dotenv\\\\Dotenv constructor invoked with 1 parameter, 3 required\\.$#"
+			count: 1
+			path: src/Configuration/DotEnvConfiguration.php
+
+		-
+			message: "#^Access to an undefined property JiraRestApi\\\\JiraClient\\:\\:\\$cookieFile\\.$#"
+			count: 1
+			path: src/JiraClient.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+	level: 0
+	paths:
+		- src
+	excludes_analyse:
+		- src/JiraRestApiServiceProvider.php


### PR DESCRIPTION
Closes #311 

:yum: Implements phpstan coverage by travis build.
Added `phpstan-baseline.neon` because of errors on analyse `level: 0`.


**Test without baseline**
![grafik](https://user-images.githubusercontent.com/4742603/81303558-23409180-907c-11ea-8262-8ee5a5fc3e69.png)


**Test with baseline**
![grafik](https://user-images.githubusercontent.com/4742603/81303499-0e63fe00-907c-11ea-98b0-e25c2276a8bc.png)


