### PR TITLE
Fixed doc comment for 'setIssueType'

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -371,7 +371,7 @@ class IssueField implements \JsonSerializable
     /**
      * set issue type.
      *
-     * @param IssueType $issueType mixed IssueType or string
+     * @param IssueType|string $issueType mixed IssueType or string
      *
      * @return $this
      */


### PR DESCRIPTION
The method `IssueField::setIssueType` accepts not only `IssueType` but also `string`.