### PR TITLE
Support leadAccountId parameter

### DIFF
--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -69,6 +69,13 @@ class Project implements \JsonSerializable
     public $lead;
 
     /**
+     * The account ID of the project lead.
+     *
+     * @var string
+     */
+    public $leadAccountId;
+
+    /**
      * ComponentList [\JiraRestApi\Project\Component].
      *
      * @var \JiraRestApi\Project\Component[]
@@ -202,6 +209,18 @@ class Project implements \JsonSerializable
     public function setLead($lead)
     {
         $this->lead = $lead;
+
+        return $this;
+    }
+
+    /**
+     * @param string $lead
+     *
+     * @return Project
+     */
+    public function setLeadAccountId($leadAccountId)
+    {
+        $this->leadAccountId = $leadAccountId;
 
         return $this;
     }


### PR DESCRIPTION
This pull request will add the leadAccountId to the project model. We cannot use the lead parameter when creating a new project via the API due to the GDPR- strict mode of our Jira cloud installation / the deprecation of the usage of usernames in favor of accountIds:
https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/