### PR TITLE
Add service desk public and private comments on requests

### DIFF
--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -234,7 +234,7 @@ class IssueService extends \JiraRestApi\JiraClient
         $this->log->info("addComment=\n");
 
         if (!($comment instanceof Comment) || empty($comment->body)) {
-            throw new JiraException('comment param must instance of Comment and have to body text.!');
+            throw new JiraException('comment param must be instance of Comment and have body text.');
         }
 
         $data = json_encode($comment);

--- a/src/Request/Author.php
+++ b/src/Request/Author.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace JiraRestApi\Request;
+
+class Author implements \JsonSerializable
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $key;
+
+    /** @var string */
+    public $emailAddress;
+
+    /** @var string */
+    public $displayName;
+
+    /** @var boolean */
+    public $active;
+
+    /** @var string */
+    public $timeZone;
+
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
+    }
+
+}

--- a/src/Request/Author.php
+++ b/src/Request/Author.php
@@ -26,5 +26,4 @@ class Author implements \JsonSerializable
     {
         return array_filter(get_object_vars($this));
     }
-
 }

--- a/src/Request/Author.php
+++ b/src/Request/Author.php
@@ -16,7 +16,7 @@ class Author implements \JsonSerializable
     /** @var string */
     public $displayName;
 
-    /** @var boolean */
+    /** @var bool */
     public $active;
 
     /** @var string */

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -41,7 +41,7 @@ class RequestComment implements \JsonSerializable
 
     public function jsonSerialize()
     {
-        return array_filter(get_object_vars($this), function($var) {
+        return array_filter(get_object_vars($this), function ($var) {
             return $var !== null;
         });
     }

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -33,11 +33,13 @@ class RequestComment implements \JsonSerializable
 
     /**
      * @param bool $public True for is public, false otherwise
+     * 
      * @return $this
      */
     public function setIsPublic(bool $public)
     {
         $this->public = $public;
+
         return $this;
     }
 

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -33,7 +33,7 @@ class RequestComment implements \JsonSerializable
 
     /**
      * @param bool $public True for is public, false otherwise
-     * 
+     *
      * @return $this
      */
     public function setIsPublic(bool $public)

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -10,7 +10,7 @@ class RequestComment implements \JsonSerializable
     /** @var string */
     public $body;
 
-    /** @var boolean */
+    /** @var bool */
     public $public;
 
     /** @var \JiraRestApi\Request\Author */
@@ -21,16 +21,18 @@ class RequestComment implements \JsonSerializable
 
     /**
      * @param string $body
+     *
      * @return $this
      */
     public function setBody(string $body)
     {
         $this->body = $body;
+
         return $this;
     }
 
     /**
-     * @param boolean $public   True for is public, false otherwise
+     * @param bool $public True for is public, false otherwise
      * @return $this
      */
     public function setIsPublic(bool $public)

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -19,8 +19,6 @@ class RequestComment implements \JsonSerializable
     /** @var \DateTimeInterface */
     public $created;
 
-    public $_links;
-
     /**
      * @param string $body
      * @return $this
@@ -32,7 +30,7 @@ class RequestComment implements \JsonSerializable
     }
 
     /**
-     * @param boolena $public
+     * @param boolean $public   True for is public, false otherwise
      * @return $this
      */
     public function setIsPublic(bool $public)

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace JiraRestApi\Request;
+
+class RequestComment implements \JsonSerializable
+{
+    /** @var string */
+    public $id;
+
+    /** @var string */
+    public $body;
+
+    /** @var boolean */
+    public $public;
+
+    /** @var \JiraRestApi\Request\Author */
+    public $author;
+
+    /** @var \DateTimeInterface */
+    public $created;
+
+    public $_links;
+
+    /**
+     * @param string $body
+     * @return $this
+     */
+    public function setBody(string $body)
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    /**
+     * @param boolena $public
+     * @return $this
+     */
+    public function setIsPublic(bool $public)
+    {
+        $this->public = $public;
+        return $this;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this), function($var) {
+            return $var !== null;
+        });
+    }
+}

--- a/src/Request/RequestService.php
+++ b/src/Request/RequestService.php
@@ -60,6 +60,5 @@ class RequestService extends \JiraRestApi\JiraClient
         );
 
         return $requestComment;
-
     }
 }

--- a/src/Request/RequestService.php
+++ b/src/Request/RequestService.php
@@ -29,6 +29,16 @@ class RequestService extends \JiraRestApi\JiraClient
         $this->setupAPIUri();
     }
 
+    /**
+     * Add the given comment to the specified request based on the provided $issueIdOrKey value. Returns a new
+     * RequestComment with the response.
+     *
+     * @param string|int $issueIdOrKey
+     * @param RequestComment $requestComment
+     * @return RequestComment
+     * @throws JiraException
+     * @throws \JsonMapper_Exception
+     */
     public function addComment($issueIdOrKey, RequestComment $requestComment): RequestComment
     {
         $this->log->info("addComment=\n");

--- a/src/Request/RequestService.php
+++ b/src/Request/RequestService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace JiraRestApi\Request;
+
+use JiraRestApi\Configuration\ConfigurationInterface;
+use JiraRestApi\JiraException;
+use JiraRestApi\ServiceDeskTrait;
+use Psr\Log\LoggerInterface;
+
+class RequestService extends \JiraRestApi\JiraClient
+{
+    use ServiceDeskTrait;
+
+    private $uri = '/request';
+
+    /**
+     * Constructor.
+     *
+     * @param ConfigurationInterface $configuration
+     * @param LoggerInterface $logger
+     * @param string $path
+     *
+     * @throws JiraException
+     * @throws \Exception
+     */
+    public function __construct(ConfigurationInterface $configuration = null, LoggerInterface $logger = null, $path = './')
+    {
+        parent::__construct($configuration, $logger, $path);
+        $this->setupAPIUri();
+    }
+
+    public function addComment($issueIdOrKey, RequestComment $requestComment): RequestComment
+    {
+        $this->log->info("addComment=\n");
+
+        if (empty($requestComment->body)) {
+            throw new JiraException('comment param must be an instance of RequestComment and have body text.');
+        }
+
+        $data = json_encode($requestComment);
+
+        $ret = $this->exec($this->uri . "/$issueIdOrKey/comment", $data);
+
+        $this->log->debug('add comment result=' . var_export($ret, true));
+        $requestComment = $this->json_mapper->map(
+            json_decode($ret),
+            new RequestComment()
+        );
+
+        return $requestComment;
+
+    }
+
+}

--- a/src/Request/RequestService.php
+++ b/src/Request/RequestService.php
@@ -17,8 +17,8 @@ class RequestService extends \JiraRestApi\JiraClient
      * Constructor.
      *
      * @param ConfigurationInterface $configuration
-     * @param LoggerInterface $logger
-     * @param string $path
+     * @param LoggerInterface        $logger
+     * @param string                 $path
      *
      * @throws JiraException
      * @throws \Exception
@@ -33,11 +33,13 @@ class RequestService extends \JiraRestApi\JiraClient
      * Add the given comment to the specified request based on the provided $issueIdOrKey value. Returns a new
      * RequestComment with the response.
      *
-     * @param string|int $issueIdOrKey
+     * @param string|int     $issueIdOrKey
      * @param RequestComment $requestComment
-     * @return RequestComment
+     *
      * @throws JiraException
      * @throws \JsonMapper_Exception
+     *
+     * @return RequestComment
      */
     public function addComment($issueIdOrKey, RequestComment $requestComment): RequestComment
     {
@@ -49,9 +51,9 @@ class RequestService extends \JiraRestApi\JiraClient
 
         $data = json_encode($requestComment);
 
-        $ret = $this->exec($this->uri . "/$issueIdOrKey/comment", $data);
+        $ret = $this->exec($this->uri."/$issueIdOrKey/comment", $data);
 
-        $this->log->debug('add comment result=' . var_export($ret, true));
+        $this->log->debug('add comment result='.var_export($ret, true));
         $requestComment = $this->json_mapper->map(
             json_decode($ret),
             new RequestComment()

--- a/src/Request/RequestService.php
+++ b/src/Request/RequestService.php
@@ -60,5 +60,4 @@ class RequestService extends \JiraRestApi\JiraClient
         return $requestComment;
 
     }
-
 }

--- a/src/ServiceDeskTrait.php
+++ b/src/ServiceDeskTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JiraRestApi;
+
+trait ServiceDeskTrait
+{
+    private function setupAPIUri($version = '')
+    {
+        $uri = '/rest/servicedeskapi';
+        $uri .= ($version != '') ? '/' . $version : '';
+        $this->setAPIUri($uri);
+    }
+}

--- a/src/ServiceDeskTrait.php
+++ b/src/ServiceDeskTrait.php
@@ -7,7 +7,7 @@ trait ServiceDeskTrait
     private function setupAPIUri($version = '')
     {
         $uri = '/rest/servicedeskapi';
-        $uri .= ($version != '') ? '/' . $version : '';
+        $uri .= ($version != '') ? '/'.$version : '';
         $this->setAPIUri($uri);
     }
 }


### PR DESCRIPTION
For a project we are working on, we need to be able to make private comments on service desk requests via the API. This adds that capability.

Tested with Jira 8.9.1 and Service Desk 4.9.1