### PR TITLE
Use absolute namespace for Reporter

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -20,7 +20,7 @@ class IssueField implements \JsonSerializable
     /** @var \JiraRestApi\Issue\IssueType */
     public $issuetype;
 
-    /** @var Reporter|null */
+    /** @var \JiraRestApi\Issue\Reporter|null */
     public $reporter;
 
     /** @var \DateTimeInterface */


### PR DESCRIPTION
Hi,
this PR modifies mapping to absolute namespace for `$reporter` property. I extend `IssueField` class in my project and JsonMapper tries to find `Reporter` class in my own application namespace. This also unifies mapping with other properties which all uses absolute namespace `\JiraRestApi\Issue\<className>`.

Thanks!