### PR TITLE
Store Jira error response into JiraException

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -301,7 +301,7 @@ class JiraClient
             if ($this->http_response != 200 && $this->http_response != 201) {
                 throw new JiraException('CURL HTTP Request Failed: Status Code : '
                     .$this->http_response.', URL:'.$url
-                    ."\nError Message : ".$response, $this->http_response);
+                    ."\nError Message : ".$response, $this->http_response, null, $response);
             }
         }
 

--- a/src/JiraException.php
+++ b/src/JiraException.php
@@ -13,4 +13,36 @@ namespace JiraRestApi;
  */
 class JiraException extends \Exception
 {
+    /**
+     * Response returned by Jira.
+     *
+     * @var string|null
+     */
+    protected $response;
+
+    /**
+     * Create a new Jira exception instance.
+     *
+     * @param  string  $message
+     * @param  int  $code
+     * @param  \Throwable  $previous
+     * @param  string  $response
+     * @return void
+     */
+    public function __construct($message = null, $code = 0, \Throwable $previous = null, $response = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->response = $response;
+    }
+
+    /**
+     * Get error response.
+     *
+     * @return string|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }


### PR DESCRIPTION
Hi,
this PR adds storing of Jira response into JiraException in case of failed request. You can than easily read it in catch block and display errors to user.

Currently it is possible to retrieve response only from exception message using regexp which is more like a workaround.

Example of usage:
```php
try {
    // some operation which throws JiraException
} catch (\JiraRestApi\JiraException $e) {
    $response = $e->getResponse();
    if ($response) {
        // request finished with status code >= 400
        $response = json_decode($response);
        $jiraErrorMessages = $response->errorMessages;
        $jiraErrors = $response->errors;
    } else {
        // request failed without response (possibly network error)
    }
}
```