### PR TITLE
Fix PHPStan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,8 +5,5 @@ parameters:
     level: 3
     paths:
         - src
-    bootstrapFiles:
-        - _ide_helper.php
-        - _ide_helper_models.php
     excludes_analyse:
         - src/JiraRestApiServiceProvider.php


### PR DESCRIPTION
Not sure why these files were included here, they do not seem to be needed and PHPStan did not run because they don't exist.

Now `vendor/bin/phpstan analyze` works fine, as you can see in Travis.