### PR TITLE
Fix PHPStan errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,26 +1,9 @@
 parameters:
     ignoreErrors:
         -
-            message: "#^Static method Dotenv\\\\Dotenv\\:\\:create\\(\\) invoked with 1 parameter, 2\\-4 required\\.$#"
-            count: 1
-            path: src/Configuration/DotEnvConfiguration.php
-
-        -
-            message: "#^Class Dotenv\\\\Dotenv constructor invoked with 1 parameter, 3 required\\.$#"
-            count: 1
-            path: src/Configuration/DotEnvConfiguration.php
-        -
-            message: "#^Call to an undefined method Monolog\\\\Logger::addInfo\\(\\)\\.$#"
-            count: 2
-            path: src/Issue/IssueService.php
-        -
             message: "#^Property JiraRestApi\\\\Issue\\\\IssueField::\\$duedate \\(DateTimeInterface|null\\) does not accept string\\.$#"
             count: 1
             path: src/Issue/IssueField.php
-        -
-            message: "#^Cannot access offset 'key' on JiraRestApi\\\\Issue\\\\Issue\\.$#"
-            count: 2
-            path: src/IssueLink/IssueLink.php
         -
             message: "#^Property JiraRestApi\\\\Issue\\\\Version::\\$releaseDate \\(DateTimeInterface|null\\) does not accept string\\.$#"
             count: 1
@@ -29,3 +12,7 @@ parameters:
             message: "#^Property JiraRestApi\\\\JiraClient::\\$log \\(Monolog\\\\Logger\\) does not accept Psr\\\\Log\\\\LoggerInterface\\.$#"
             count: 1
             path: src/JiraClient.php
+        -
+            message: "#^Property JiraRestApi\\\\Issue\\\\RemoteIssueLink::\\$object \\(JiraRestApi\\\\Issue\\\\RemoteIssueLinkObject|null\\) does not accept JiraRestApi\\\\Issue\\\\RemoteIssueLink\\.$#"
+            count: 1
+            path: src/Issue/RemoteIssueLink.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,3 +16,6 @@ parameters:
             message: "#^Property JiraRestApi\\\\Issue\\\\RemoteIssueLink::\\$object \\(JiraRestApi\\\\Issue\\\\RemoteIssueLinkObject|null\\) does not accept JiraRestApi\\\\Issue\\\\RemoteIssueLink\\.$#"
             count: 1
             path: src/Issue/RemoteIssueLink.php
+        -
+            message: "#^Call to function is_.+ with .+ will always evaluate to false\\.$#"
+            path: src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 3
+    level: 5
     paths:
         - src
     excludes_analyse:

--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -143,12 +143,12 @@ class DotEnvConfiguration extends AbstractConfiguration
                 $dotenv->safeLoad();
                 $dotenv->required($requireParam);
             } elseif (method_exists('\Dotenv\Dotenv', 'create')) {    // v3
-                $dotenv = \Dotenv\Dotenv::create($path);
+                $dotenv = \Dotenv\Dotenv::create($path); // @phpstan-ignore-line
 
                 $dotenv->safeLoad();
                 $dotenv->required($requireParam);
             } else {    // v2
-                $dotenv = new \Dotenv\Dotenv($path);
+                $dotenv = new \Dotenv\Dotenv($path); // @phpstan-ignore-line
 
                 $dotenv->load();
                 $dotenv->required($requireParam);

--- a/src/Issue/JqlQuery.php
+++ b/src/Issue/JqlQuery.php
@@ -442,7 +442,7 @@ class JqlQuery
      *
      * JqlQuery::quote(JqlFunction::now()) returns 'now()'
      *
-     * @param string $value
+     * @param string|JqlFunction $value
      *
      * @return string
      */

--- a/src/Issue/VisibilityTrait.php
+++ b/src/Issue/VisibilityTrait.php
@@ -5,8 +5,8 @@ namespace JiraRestApi\Issue;
 trait VisibilityTrait
 {
     /**
-     * @param Visibility $type
-     * @param null       $value
+     * @param Visibility  $type
+     * @param mixed|null  $value
      *
      * @return $this
      */
@@ -21,7 +21,7 @@ trait VisibilityTrait
             $this->visibility->setValue($type['value']);
         } elseif ($type instanceof Visibility) {
             $this->visibility = $type;
-        } else {
+        } else { // @phpstan-ignore-line We cannot fix phpdoc to make this "reachable" because of JsonMapper
             $this->visibility->setType($type);
             $this->visibility->setValue($value);
         }

--- a/src/IssueType/IssueTypeService.php
+++ b/src/IssueType/IssueTypeService.php
@@ -2,6 +2,7 @@
 
 namespace JiraRestApi\IssueType;
 
+use JiraRestApi\Issue\IssueType;
 use JiraRestApi\JiraException;
 use JsonMapper_Exception;
 
@@ -25,7 +26,7 @@ class IssueTypeService extends \JiraRestApi\JiraClient
         return $this->json_mapper->mapArray(
             json_decode($ret, false),
             new \ArrayObject(),
-            \JiraRestApi\Issue\IssueType::class
+            IssueType::class
         );
     }
 }

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -193,7 +193,7 @@ class JiraClient
      * Execute REST request.
      *
      * @param string $context        Rest API context (ex.:issue, search, etc..)
-     * @param string $post_data
+     * @param string|array|null $post_data
      * @param string $custom_request [PUT|DELETE]
      * @param string $cookieFile     cookie file
      *

--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -214,7 +214,7 @@ class Project implements \JsonSerializable
     }
 
     /**
-     * @param string $lead
+     * @param string $leadAccountId
      *
      * @return Project
      */

--- a/src/StatusCategory/StatusCategoryService.php
+++ b/src/StatusCategory/StatusCategoryService.php
@@ -2,6 +2,7 @@
 
 namespace JiraRestApi\StatusCategory;
 
+use JiraRestApi\Issue\Statuscategory;
 use JiraRestApi\JiraException;
 use JsonMapper_Exception;
 


### PR DESCRIPTION
Fixed PHPStan errors, now it is green :tada: 

Also increased level to 5, it mostly added some basic PHPDoc mistakes. 

Also there were errors that things [like this](https://github.com/lesstif/php-jira-rest-client/blob/1ca81b97a82e4ae1b3ff0821aa6afc89f2f60219/src/Issue/Transition.php#L33) are always false. It seems like it could make sense to either add `|null` in PHPDoc or initialize in the field definition. But I guess it may affect JSON mapping (at least the first approach), so I disabled these errors for now.