### PR TITLE
jira_client_optional_curl_opts | added CURLOPT_CONNECTTIMEOUT

### DIFF
--- a/src/Configuration/AbstractConfiguration.php
+++ b/src/Configuration/AbstractConfiguration.php
@@ -145,6 +145,9 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     /** @var string */
     protected $curlOptSslKeyPassword;
 
+    /** @var int */
+    protected $timeout;
+
     /**
      * @return string
      */
@@ -333,5 +336,13 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     public function getUseV3RestApi()
     {
         return $this->useV3RestApi;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
     }
 }

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -158,4 +158,11 @@ interface ConfigurationInterface
      * @return bool
      */
     public function getUseV3RestApi();
+
+    /**
+     * The number of seconds to wait while trying to connect
+     *
+     * @return int
+     */
+    public function getTimeout();
 }

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -160,7 +160,7 @@ interface ConfigurationInterface
     public function getUseV3RestApi();
 
     /**
-     * The number of seconds to wait while trying to connect
+     * The number of seconds to wait while trying to connect.
      *
      * @return int
      */

--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -41,6 +41,8 @@ class DotEnvConfiguration extends AbstractConfiguration
         $this->proxyPassword = $this->env('PROXY_PASSWORD');
 
         $this->useV3RestApi = $this->env('JIRA_REST_API_V3');
+
+        $this->timeout = $this->env('JIRA_TIMEOUT');
     }
 
     /**

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -732,5 +732,4 @@ class JiraClient
     {
         return $this->jsonOptions;
     }
-
 }

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -251,6 +251,9 @@ class JiraClient
         if ($this->getConfiguration()->isCurlOptSslKeyPassword()) {
             curl_setopt($ch, CURLOPT_SSLKEYPASSWD, $this->getConfiguration()->isCurlOptSslKeyPassword());
         }
+        if ($this->getConfiguration()->getTimeout()) {
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConfiguration()->getTimeout());
+        }
 
         curl_setopt($ch, CURLOPT_USERAGENT, $this->getConfiguration()->getCurlOptUserAgent());
 
@@ -365,6 +368,9 @@ class JiraClient
         }
         if ($this->getConfiguration()->isCurlOptSslKeyPassword()) {
             curl_setopt($ch, CURLOPT_SSLKEYPASSWD, $this->getConfiguration()->isCurlOptSslKeyPassword());
+        }
+        if ($this->getConfiguration()->getTimeout()) {
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConfiguration()->getTimeout());
         }
 
         $this->proxyConfigCurlHandle($ch);
@@ -587,6 +593,9 @@ class JiraClient
         if ($this->getConfiguration()->isCurlOptSslKeyPassword()) {
             curl_setopt($ch, CURLOPT_SSLKEYPASSWD, $this->getConfiguration()->isCurlOptSslKeyPassword());
         }
+        if ($this->getConfiguration()->getTimeout()) {
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConfiguration()->getTimeout());
+        }
 
         $this->proxyConfigCurlHandle($ch);
 
@@ -723,4 +732,5 @@ class JiraClient
     {
         return $this->jsonOptions;
     }
+
 }


### PR DESCRIPTION
In some cases when Jira is not available it can be useful to specify a timeout to prevent the application from freezing.

P.S.
there is a suggestion to add the ability of adding custom CURL options for next request via method in JiraClient class, what do you think about it?