### PR TITLE
related to #352 - environment variables cannot be always read 

### DIFF
--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -55,7 +55,14 @@ class DotEnvConfiguration extends AbstractConfiguration
      */
     private function env($key, $default = null)
     {
-        $value = $_ENV[$key] ?? null;
+
+        // Fallback for frameworks like Laravel as the $_ENV method might not work in all
+        // circumstances. ie when running scheduled jobs.
+        if (function_exists('env') && is_callable('env')) {
+            $value = call_user_func('env', $key) ?? null;
+        } else {
+            $value = $_ENV[$key] ?? null;
+        }
 
         if ($value === false) {
             return $default;


### PR DESCRIPTION
I'm still running into the issue outlined in #352 witht he most recent code. 

In my case I'm running getAllProjects() from within a scheduled Laravel job. This fails due to $_ENV not being sufficient to read this variables. 

A simple workaround for me was to fallback to the existing env() method, but I am aware that this might not be the best approach as it is not framework agnostic, but I still wanted to put this workaround out there as it may help others.