### PR TITLE
Issue #390 notify users update labels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lesstif/php-jira-rest-client",
+    "name": "phill54/php-jira-rest-client",
     "description": "JIRA REST API Client for PHP Users.",
     "type": "library",
     "keywords": ["jira", "rest", "jira-php", "jira-rest"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phill54/php-jira-rest-client",
+    "name": "lesstif/php-jira-rest-client",
     "description": "JIRA REST API Client for PHP Users.",
     "type": "library",
     "keywords": ["jira", "rest", "jira-php", "jira-rest"],

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -1170,7 +1170,35 @@ class IssueService extends \JiraRestApi\JiraClient
 
         $this->log->info("Update labels=\n".$postData);
 
-        $queryParam = '?'.http_build_query(['notifyUsers' => $notifyUsers]);
+        /* orignal code was
+         * $queryParam = '?'.http_build_query(['notifyUsers' => $notifyUsers]);
+         * which results in 
+         * /issue/ISSUE-1234?notifyUsers=0 or
+         * /issue/ISSUE-1234?notifyUsers=1
+         * 
+         * this has two issues:
+         * 
+         * #1
+         * the rest-api is expecting a string. any other value than
+         * /issue/ISSUE-1234?notifyUsers=false or
+         * /issue/ISSUE-1234?notifyUsers=true
+         * will cause a 403 response with the errorMessage
+         * "To discard the user notification either admin or project admin permissions are required."
+         * but only if you dont have admin or project admin permissions. (!)
+         * 
+         * #2
+         * this is default
+         * /issue/ISSUE-1234?notifyUsers=true
+         * so there's no need to add this
+         */ 
+        $queryParam = ''; 
+        if ($notifyUsers === false) {
+            $queryParam = '?'.http_build_query(['notifyUsers' => 'false']);
+        }
+        /* optional passing the default argument explicitly */
+        // else {
+        //     $queryParam = '?'.http_build_query(['notifyUsers' => 'true']);
+        // }
 
         $ret = $this->exec($this->uri."/$issueIdOrKey".$queryParam, $postData, 'PUT');
 

--- a/src/Issue/IssueService.php
+++ b/src/Issue/IssueService.php
@@ -1172,12 +1172,12 @@ class IssueService extends \JiraRestApi\JiraClient
 
         /* orignal code was
          * $queryParam = '?'.http_build_query(['notifyUsers' => $notifyUsers]);
-         * which results in 
+         * which results in
          * /issue/ISSUE-1234?notifyUsers=0 or
          * /issue/ISSUE-1234?notifyUsers=1
-         * 
+         *
          * this has two issues:
-         * 
+         *
          * #1
          * the rest-api is expecting a string. any other value than
          * /issue/ISSUE-1234?notifyUsers=false or
@@ -1185,13 +1185,13 @@ class IssueService extends \JiraRestApi\JiraClient
          * will cause a 403 response with the errorMessage
          * "To discard the user notification either admin or project admin permissions are required."
          * but only if you dont have admin or project admin permissions. (!)
-         * 
+         *
          * #2
          * this is default
          * /issue/ISSUE-1234?notifyUsers=true
          * so there's no need to add this
-         */ 
-        $queryParam = ''; 
+         */
+        $queryParam = '';
         if ($notifyUsers === false) {
             $queryParam = '?'.http_build_query(['notifyUsers' => 'false']);
         }


### PR DESCRIPTION
this is my fix for issue #390

/* orignal code was
         * $queryParam = '?'.http_build_query(['notifyUsers' => $notifyUsers]);
         * which results in 
         * /issue/ISSUE-1234?notifyUsers=0 or
         * /issue/ISSUE-1234?notifyUsers=1
         * 
         * this has two issues:
         * 
         * #1
         * the rest-api is expecting a string. any other value than
         * /issue/ISSUE-1234?notifyUsers=false or
         * /issue/ISSUE-1234?notifyUsers=true
         * will cause a 403 response with the errorMessage
         * "To discard the user notification either admin or project admin permissions are required."
         * but only if you dont have admin or project admin permissions. (!)
         * 
         * #2
         * this is default
         * /issue/ISSUE-1234?notifyUsers=true
         * so there's no need to add this
         */ 