### PR TITLE
Argument to file_exists() must be string

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -512,7 +512,7 @@ class JiraClient
         }
 
         // if cookie file not exist, using id/pwd login
-        if (!file_exists($cookieFile)) {
+        if (!is_string($cookieFile) || !file_exists($cookieFile)) {
             if ($this->getConfiguration()->isTokenBasedAuth() === true) {
                 $curl_http_headers[] = 'Authorization: Bearer '.$this->getConfiguration()->getPeronalAccessToken();
             } else {


### PR DESCRIPTION
Fixes problem in PHP 8.1:
```
Deprecated: file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in vendor/lesstif/php-jira-rest-client/src/JiraClient.php on line 515
```
