### PR TITLE
Fix return type JsonSerializable implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "keywords": ["jira", "rest", "jira-php", "jira-rest"],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "netresearch/jsonmapper": "^2.0|^3.0|^4.0",

--- a/src/Auth/AuthSession.php
+++ b/src/Auth/AuthSession.php
@@ -18,7 +18,7 @@ class AuthSession implements \JsonSerializable
      */
     public $loginInfo;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Auth/CurrentUser.php
+++ b/src/Auth/CurrentUser.php
@@ -23,7 +23,7 @@ class CurrentUser implements \JsonSerializable
      */
     public $loginInfo;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Auth/LoginInfo.php
+++ b/src/Auth/LoginInfo.php
@@ -32,7 +32,7 @@ class LoginInfo implements \JsonSerializable
      */
     public $previousLoginTime;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Auth/SessionInfo.php
+++ b/src/Auth/SessionInfo.php
@@ -18,7 +18,7 @@ class SessionInfo implements \JsonSerializable
      */
     public $value;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Board/Board.php
+++ b/src/Board/Board.php
@@ -67,7 +67,7 @@ class Board implements \JsonSerializable
         return $this->location;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Board/Location.php
+++ b/src/Board/Location.php
@@ -84,7 +84,7 @@ class Location implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Component/Component.php
+++ b/src/Component/Component.php
@@ -148,7 +148,7 @@ class Component implements \JsonSerializable
     /**
      * @return array|mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -111,7 +111,7 @@ class Field implements \JsonSerializable
     /* @var Schema */
     public $schema;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -36,7 +36,7 @@ class Group implements \JsonSerializable
      */
     public $expand;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Group/GroupSearchResult.php
+++ b/src/Group/GroupSearchResult.php
@@ -39,7 +39,7 @@ class GroupSearchResult implements \JsonSerializable
     /** @var \JiraRestApi\User\User[] */
     public $values;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Attachment.php
+++ b/src/Issue/Attachment.php
@@ -31,7 +31,7 @@ class Attachment implements \JsonSerializable
     /* @var string */
     public $thumbnail;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/ChangeLog.php
+++ b/src/Issue/ChangeLog.php
@@ -21,7 +21,7 @@ class ChangeLog implements \JsonSerializable
     /** @var \JiraRestApi\Issue\History[]|null */
     public $histories;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Comment.php
+++ b/src/Issue/Comment.php
@@ -37,7 +37,7 @@ class Comment implements \JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Comments.php
+++ b/src/Issue/Comments.php
@@ -16,7 +16,7 @@ class Comments implements \JsonSerializable
     /** @var \JiraRestApi\Issue\Comment[] */
     public $comments;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Component.php
+++ b/src/Issue/Component.php
@@ -12,7 +12,7 @@ class Component implements \JsonSerializable
         $this->name = $name;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/ContentField.php
+++ b/src/Issue/ContentField.php
@@ -18,7 +18,7 @@ class ContentField implements \JsonSerializable
         $this->content = [];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/CustomFieldUsage.php
+++ b/src/Issue/CustomFieldUsage.php
@@ -17,7 +17,7 @@ class CustomFieldUsage implements \JsonSerializable
     {
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/DescriptionV3.php
+++ b/src/Issue/DescriptionV3.php
@@ -21,7 +21,7 @@ class DescriptionV3 implements \JsonSerializable
     /** @var \JiraRestApi\Issue\ContentField[]|null */
     public $content;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/History.php
+++ b/src/Issue/History.php
@@ -21,7 +21,7 @@ class History implements \JsonSerializable
     /** @var array|null */
     public $items;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -44,7 +44,7 @@ class Issue implements \JsonSerializable
     /** @var \JiraRestApi\Issue\ChangeLog|null */
     public $changelog;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -138,7 +138,7 @@ class IssueField implements \JsonSerializable
         }
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $vars = array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Issue/IssueStatus.php
+++ b/src/Issue/IssueStatus.php
@@ -22,7 +22,7 @@ class IssueStatus implements \JsonSerializable
     /* @var \JiraRestApi\Issue\Statuscategory */
     public $statuscategory;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/IssueType.php
+++ b/src/Issue/IssueType.php
@@ -28,7 +28,7 @@ class IssueType implements \JsonSerializable
     /** @var int */
     public $avatarId;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/IssueV3.php
+++ b/src/Issue/IssueV3.php
@@ -7,7 +7,7 @@ class IssueV3 extends Issue
     /** @var \JiraRestApi\Issue\IssueFieldV3 */
     public $fields;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Notify.php
+++ b/src/Issue/Notify.php
@@ -124,7 +124,7 @@ class Notify implements \JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Priority.php
+++ b/src/Issue/Priority.php
@@ -22,7 +22,7 @@ class Priority implements \JsonSerializable
     /** @var string */
     public $description;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/RemoteIssueLink.php
+++ b/src/Issue/RemoteIssueLink.php
@@ -22,7 +22,7 @@ class RemoteIssueLink implements \JsonSerializable
     /** @var \JiraRestApi\Issue\RemoteIssueLinkObject|null */
     public $object;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Reporter.php
+++ b/src/Issue/Reporter.php
@@ -32,7 +32,7 @@ class Reporter implements \JsonSerializable
     /** @var string */
     public $accountId;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $vars = (get_object_vars($this));
 
@@ -47,7 +47,7 @@ class Reporter implements \JsonSerializable
         }
 
         if (empty($vars)) {
-            return;
+            return null;
         }
 
         return $vars;

--- a/src/Issue/SecurityScheme.php
+++ b/src/Issue/SecurityScheme.php
@@ -22,7 +22,7 @@ class SecurityScheme implements \JsonSerializable
     /** @var array security level */
     public $levels;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/TimeTracking.php
+++ b/src/Issue/TimeTracking.php
@@ -166,7 +166,7 @@ class TimeTracking implements \JsonSerializable
      * @return mixed data which can be serialized by <b>json_encode</b>,
      *               which is a value of any type other than a resource.
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Transition.php
+++ b/src/Issue/Transition.php
@@ -72,7 +72,7 @@ class Transition implements \JsonSerializable
         array_push($this->update['comment'], $ar);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -39,7 +39,7 @@ class Version implements \JsonSerializable
         $this->name = $name;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/VersionIssueCounts.php
+++ b/src/Issue/VersionIssueCounts.php
@@ -23,7 +23,7 @@ class VersionIssueCounts implements \JsonSerializable
     {
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/VersionUnresolvedCount.php
+++ b/src/Issue/VersionUnresolvedCount.php
@@ -10,7 +10,7 @@ class VersionUnresolvedCount implements \JsonSerializable
     /** @var int */
     public $issuesUnresolvedCount;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Visibility.php
+++ b/src/Issue/Visibility.php
@@ -27,7 +27,7 @@ class Visibility implements \JsonSerializable
         return $this->value;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Worklog.php
+++ b/src/Issue/Worklog.php
@@ -71,7 +71,7 @@ class Worklog
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/IssueLink/IssueLink.php
+++ b/src/IssueLink/IssueLink.php
@@ -21,7 +21,7 @@ class IssueLink implements \JsonSerializable
     /** @var \JiraRestApi\Issue\Comment */
     public $comment;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $vars = array_filter(get_object_vars($this));
 

--- a/src/IssueLink/IssueLinkType.php
+++ b/src/IssueLink/IssueLinkType.php
@@ -28,7 +28,7 @@ class IssueLinkType implements \JsonSerializable
     /** @var string */
     public $self;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $vars = array_filter(get_object_vars($this));
 

--- a/src/JsonSerializableTrait.php
+++ b/src/JsonSerializableTrait.php
@@ -4,7 +4,7 @@ namespace JiraRestApi;
 
 trait JsonSerializableTrait
 {
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -122,7 +122,7 @@ class Project implements \JsonSerializable
     /** @var int */
     public $categoryId;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Request/Author.php
+++ b/src/Request/Author.php
@@ -22,7 +22,7 @@ class Author implements \JsonSerializable
     /** @var string */
     public $timeZone;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -43,7 +43,7 @@ class RequestComment implements \JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this), function ($var) {
             return $var !== null;

--- a/src/Status/Status.php
+++ b/src/Status/Status.php
@@ -13,7 +13,7 @@ class Status implements \JsonSerializable
     /** @var string */
     public $description;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -75,7 +75,7 @@ class User implements \JsonSerializable
      */
     public $password;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter(get_object_vars($this));
     }


### PR DESCRIPTION
To be compatible with PHP 8.1.

```
Deprecated: Return type of JiraRestApi\Issue\IssueField::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/lesstif/php-jira-rest-client/src/Issue/IssueField.php on line 141
```

The mixed return type was introduced in PHP 8.0. This pull request makes the code incompatible with PHP 7.x.