### PR TITLE
Catch passing null to strtolower

### DIFF
--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -64,7 +64,7 @@ class DotEnvConfiguration extends AbstractConfiguration
             return $default;
         }
 
-        switch ($value === null ?? 'null' : strtolower($value)) {
+        switch ($value === null ? 'null' : strtolower($value)) {
             case 'true':
             case '(true)':
                 return true;

--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -64,7 +64,7 @@ class DotEnvConfiguration extends AbstractConfiguration
             return $default;
         }
 
-        switch (strtolower($value)) {
+        switch ($value === null ?? 'null' : strtolower($value)) {
             case 'true':
             case '(true)':
                 return true;


### PR DESCRIPTION
PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in lesstif/php-jira-rest-client/src/Configuration/DotEnvConfiguration.php on line 67

#untested