### PR TITLE
Change type declaration of IssueField::addCustomField to allow integer and float values

### DIFF
--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -150,7 +150,7 @@ class IssueField implements \JsonSerializable
         return $this->customFields;
     }
 
-    public function addCustomField(string $key, string $value): static
+    public function addCustomField(string $key, string|int|float $value): static
     {
         $this->customFields[$key] = $value;
 


### PR DESCRIPTION
Solves a situation where you would get an error if you would update a custom field of type 'Number field'. 

Error Message: 
```{"errorMessages":[],"errors":{"customfield_11152":"Specify a number for the custom field (below 100,000,000,000,000)"}}```

Reproduce: 
```
$issueKey = 'PRO-123';
$number = 50;

$numberField = new IssueField(true);
$numberField->addCustomField('customfield_11152', $number);

$editParams = [
'notifyUsers' => false,
];

$ret = $this->issueService->update($issueKey, $numberField, $editParams);
```

_Make sure `customfield_11152` is of type 'Number field'_