### PR TITLE
Bugfix/issue status description nullable

### DIFF
--- a/src/Status/Status.php
+++ b/src/Status/Status.php
@@ -10,7 +10,7 @@ class Status implements \JsonSerializable
     /** @var string */
     public $name;
 
-    /** @var string */
+    /** @var string|null */
     public ?string $description = null;
 
     #[\ReturnTypeWillChange]


### PR DESCRIPTION
Issue status description is nullable in JIra.

Will this change also be applied to [https://github.com/lesstif/php-JiraCloud-RESTAPI](https://github.com/lesstif/php-JiraCloud-RESTAPI)?

Thanks!