### PR TITLE
Replaced missing AgileApiTrait with setApiUri function

### DIFF
--- a/src/Issue/AgileIssueService.php
+++ b/src/Issue/AgileIssueService.php
@@ -14,7 +14,7 @@ class AgileIssueService extends \JiraRestApi\JiraClient
     public function __construct(ConfigurationInterface $configuration = null, LoggerInterface $logger = null, $path = './')
     {
         parent::__construct($configuration, $logger, $path);
-        $this->setAPIUri('/rest/agile/' . $this->agileVersion);
+        $this->setAPIUri('/rest/agile/'.$this->agileVersion);
     }
 
     public function get($issueIdOrKey, $paramArray = []): ?AgileIssue

--- a/src/Issue/AgileIssueService.php
+++ b/src/Issue/AgileIssueService.php
@@ -2,20 +2,19 @@
 
 namespace JiraRestApi\Issue;
 
-use JiraRestApi\AgileApiTrait;
 use JiraRestApi\Configuration\ConfigurationInterface;
 use Psr\Log\LoggerInterface;
 
 class AgileIssueService extends \JiraRestApi\JiraClient
 {
-    use AgileApiTrait;
-
     private $uri = '/issue';
+
+    private $agileVersion = '1.0';
 
     public function __construct(ConfigurationInterface $configuration = null, LoggerInterface $logger = null, $path = './')
     {
         parent::__construct($configuration, $logger, $path);
-        $this->setupAPIUri();
+        $this->setAPIUri('/rest/agile/' . $this->agileVersion);
     }
 
     public function get($issueIdOrKey, $paramArray = []): ?AgileIssue


### PR DESCRIPTION
`AgileApiTrait` is missing from the package, to fix the `AgileIssueService` from breaking I have replaced the method called from `AgileApiTrait` with the `setApiUri` function. 