### PR TITLE
Added compatibility with PHP 8.2

### DIFF
--- a/src/JsonMapperHelper.php
+++ b/src/JsonMapperHelper.php
@@ -15,6 +15,7 @@ class JsonMapperHelper
      */
     public static function setUndefinedProperty($object, $propName, $jsonValue)
     {
+        $object = (object)(array) $object;
         // If the property is a custom field type, assign a value to the custom Fields array.
         if (substr($propName, 0, 12) == 'customfield_') {
             if (!is_null($jsonValue)) {


### PR DESCRIPTION
This is a patch for avoiding the warning given by PHP version 8.2, when dynamic properties are used. https://php.watch/versions/8.2/dynamic-properties-deprecated

Patch found at https://stackoverflow.com/a/17731862

Fixes #486.