### PR TITLE
Add version to ContentField

### DIFF
--- a/src/Issue/ContentField.php
+++ b/src/Issue/ContentField.php
@@ -13,6 +13,9 @@ class ContentField implements \JsonSerializable
     /** @var array */
     public $attrs;
 
+    /** @var string */
+    public $version;
+
     public function __construct()
     {
         $this->content = [];


### PR DESCRIPTION
I don't know why, but without the version it doesn't work for me.

And in PHP 8.2 I get a warning, that I should not create dynamic properties :-)