### PR TITLE
Tackle further PHP 8.2 deprecation warnings.

### DIFF
--- a/src/Issue/IssueType.php
+++ b/src/Issue/IssueType.php
@@ -21,6 +21,8 @@ class IssueType implements \JsonSerializable
 
     public int $avatarId;
 
+    public int $hierarchyLevel;
+
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/src/Issue/Reporter.php
+++ b/src/Issue/Reporter.php
@@ -29,6 +29,14 @@ class Reporter implements \JsonSerializable
 
     public string $accountId;
 
+    public string $locale;
+
+    public array $groups;
+
+    public array $applicationRoles;
+
+    public string $expand;
+
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/src/Issue/Transition.php
+++ b/src/Issue/Transition.php
@@ -28,6 +28,18 @@ class Transition implements \JsonSerializable
     /** @var array */
     public $update;
 
+    public bool $isConditional;
+
+    public bool $isLooped;
+
+    public bool $hasScreen;
+
+    public bool $isGlobal;
+
+    public bool $isAvailable;
+
+    public bool $isInitial;
+
     public function setTransitionName($name)
     {
         if (is_null($this->transition)) {

--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -95,6 +95,14 @@ class Project implements \JsonSerializable
 
     public int $categoryId;
 
+    public bool $simplified;
+
+    public string $style;
+
+    public bool $isPrivate;
+
+    public array $properties;
+
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
This PR tackles further deprecation warnings that are thrown under PHP 8.2 for relying on dynamic property creation.