### PR TITLE
Refactored IssueStatus $description to accept null

### DIFF
--- a/src/Issue/IssueStatus.php
+++ b/src/Issue/IssueStatus.php
@@ -11,7 +11,7 @@ class IssueStatus implements \JsonSerializable
     public $id;
 
     /* @var string|null */
-    public $description;
+    public ?string $description = null;
 
     /* @var string */
     public $iconUrl;


### PR DESCRIPTION
Issue status description is nullable in JIra. 
This has been fixed in the Status::class (see pr: https://github.com/lesstif/php-jira-rest-client/pull/477) however has not been fixed in the IssueStatus ::class.