### PR TITLE
Add return types to jsonSerialize to suppress deprecation message.

### DIFF
--- a/src/Auth/AuthSession.php
+++ b/src/Auth/AuthSession.php
@@ -19,7 +19,7 @@ class AuthSession implements \JsonSerializable
     public $loginInfo;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Auth/CurrentUser.php
+++ b/src/Auth/CurrentUser.php
@@ -24,7 +24,7 @@ class CurrentUser implements \JsonSerializable
     public $loginInfo;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Auth/LoginInfo.php
+++ b/src/Auth/LoginInfo.php
@@ -33,7 +33,7 @@ class LoginInfo implements \JsonSerializable
     public $previousLoginTime;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Auth/SessionInfo.php
+++ b/src/Auth/SessionInfo.php
@@ -19,7 +19,7 @@ class SessionInfo implements \JsonSerializable
     public $value;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Board/Board.php
+++ b/src/Board/Board.php
@@ -68,7 +68,7 @@ class Board implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Board/Location.php
+++ b/src/Board/Location.php
@@ -85,7 +85,7 @@ class Location implements \JsonSerializable
      * {@inheritdoc}
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Component/Component.php
+++ b/src/Component/Component.php
@@ -92,12 +92,10 @@ class Component implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
-        $vars = array_filter(get_object_vars($this), function ($var) {
+        return array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);
         });
-
-        return $vars;
     }
 }

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -112,7 +112,7 @@ class Field implements \JsonSerializable
     public $schema;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -37,7 +37,7 @@ class Group implements \JsonSerializable
     public $expand;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Group/GroupSearchResult.php
+++ b/src/Group/GroupSearchResult.php
@@ -40,7 +40,7 @@ class GroupSearchResult implements \JsonSerializable
     public $values;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Attachment.php
+++ b/src/Issue/Attachment.php
@@ -32,7 +32,7 @@ class Attachment implements \JsonSerializable
     public $thumbnail;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/ChangeLog.php
+++ b/src/Issue/ChangeLog.php
@@ -22,7 +22,7 @@ class ChangeLog implements \JsonSerializable
     public $histories;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Comment.php
+++ b/src/Issue/Comment.php
@@ -38,7 +38,7 @@ class Comment implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Comments.php
+++ b/src/Issue/Comments.php
@@ -20,7 +20,7 @@ class Comments implements \JsonSerializable
     public $comments;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Component.php
+++ b/src/Issue/Component.php
@@ -13,7 +13,7 @@ class Component implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/ContentField.php
+++ b/src/Issue/ContentField.php
@@ -22,7 +22,7 @@ class ContentField implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/CustomFieldUsage.php
+++ b/src/Issue/CustomFieldUsage.php
@@ -18,7 +18,7 @@ class CustomFieldUsage implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/History.php
+++ b/src/Issue/History.php
@@ -22,7 +22,7 @@ class History implements \JsonSerializable
     public $items;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -32,7 +32,7 @@ class Issue implements \JsonSerializable
     public ?ChangeLog $changelog;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -111,7 +111,7 @@ class IssueField implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $vars = array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -120,12 +120,10 @@ class IssueField implements \JsonSerializable
         // if assignee property has empty value then remove it.
         // @see https://github.com/lesstif/php-jira-rest-client/issues/126
         // @see https://github.com/lesstif/php-jira-rest-client/issues/177
-        if (!empty($this->assignee)) {
-            // do nothing
-            if ($this->assignee->isWantUnassigned() === true) {
-            } elseif ($this->assignee->isEmpty()) {
-                unset($vars['assignee']);
-            }
+        if (!empty($this->assignee) &&
+            $this->assignee->isWantUnassigned() !== true &&
+            $this->assignee->isEmpty()) {
+            unset($vars['assignee']);
         }
 
         // clear undefined json property

--- a/src/Issue/IssueStatus.php
+++ b/src/Issue/IssueStatus.php
@@ -23,7 +23,7 @@ class IssueStatus implements \JsonSerializable
     public $statuscategory;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/IssueType.php
+++ b/src/Issue/IssueType.php
@@ -24,7 +24,7 @@ class IssueType implements \JsonSerializable
     public int $hierarchyLevel;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Notify.php
+++ b/src/Issue/Notify.php
@@ -125,7 +125,7 @@ class Notify implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Priority.php
+++ b/src/Issue/Priority.php
@@ -23,7 +23,7 @@ class Priority implements \JsonSerializable
     public $description;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/RemoteIssueLink.php
+++ b/src/Issue/RemoteIssueLink.php
@@ -23,7 +23,7 @@ class RemoteIssueLink implements \JsonSerializable
     public $object;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Reporter.php
+++ b/src/Issue/Reporter.php
@@ -44,7 +44,7 @@ class Reporter implements \JsonSerializable
     #[\ReturnTypeWillChange]
     public function jsonSerialize(): ?array
     {
-        $vars = (get_object_vars($this));
+        $vars = get_object_vars($this);
 
         foreach ($vars as $key => $value) {
             if ($key === 'name' && ($this->isWantUnassigned() === true)) {

--- a/src/Issue/Reporter.php
+++ b/src/Issue/Reporter.php
@@ -42,7 +42,7 @@ class Reporter implements \JsonSerializable
     public string $accountType;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): ?array
     {
         $vars = (get_object_vars($this));
 

--- a/src/Issue/SecurityScheme.php
+++ b/src/Issue/SecurityScheme.php
@@ -23,7 +23,7 @@ class SecurityScheme implements \JsonSerializable
     public $levels;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/TimeTracking.php
+++ b/src/Issue/TimeTracking.php
@@ -163,11 +163,11 @@ class TimeTracking implements \JsonSerializable
      *
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * @return array data which can be serialized by <b>json_encode</b>,
      *               which is a value of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Transition.php
+++ b/src/Issue/Transition.php
@@ -85,7 +85,7 @@ class Transition implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -37,7 +37,7 @@ class Version implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/VersionIssueCounts.php
+++ b/src/Issue/VersionIssueCounts.php
@@ -24,7 +24,7 @@ class VersionIssueCounts implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/VersionUnresolvedCount.php
+++ b/src/Issue/VersionUnresolvedCount.php
@@ -11,7 +11,7 @@ class VersionUnresolvedCount implements \JsonSerializable
     public $issuesUnresolvedCount;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Visibility.php
+++ b/src/Issue/Visibility.php
@@ -28,7 +28,7 @@ class Visibility implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Issue/Worklog.php
+++ b/src/Issue/Worklog.php
@@ -76,7 +76,7 @@ class Worklog
      * @return array
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/IssueLink/IssueLink.php
+++ b/src/IssueLink/IssueLink.php
@@ -22,11 +22,9 @@ class IssueLink implements \JsonSerializable
     public $comment;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
-        $vars = array_filter(get_object_vars($this));
-
-        return $vars;
+        return array_filter(get_object_vars($this));
     }
 
     /**

--- a/src/IssueLink/IssueLinkType.php
+++ b/src/IssueLink/IssueLinkType.php
@@ -29,10 +29,8 @@ class IssueLinkType implements \JsonSerializable
     public $self;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
-        $vars = array_filter(get_object_vars($this));
-
-        return $vars;
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/JsonSerializableTrait.php
+++ b/src/JsonSerializableTrait.php
@@ -5,7 +5,7 @@ namespace JiraRestApi;
 trait JsonSerializableTrait
 {
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -106,7 +106,7 @@ class Project implements \JsonSerializable
     public bool $archived;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $params = array_filter(get_object_vars($this), function ($var) {
             return !is_null($var);

--- a/src/Request/Author.php
+++ b/src/Request/Author.php
@@ -23,7 +23,7 @@ class Author implements \JsonSerializable
     public $timeZone;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/Request/RequestComment.php
+++ b/src/Request/RequestComment.php
@@ -44,7 +44,7 @@ class RequestComment implements \JsonSerializable
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this), function ($var) {
             return $var !== null;

--- a/src/Status/Status.php
+++ b/src/Status/Status.php
@@ -14,7 +14,7 @@ class Status implements \JsonSerializable
     public ?string $description = null;
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -12,7 +12,7 @@ use JiraRestApi\Issue\Reporter;
 class User extends Reporter
 {
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this));
     }


### PR DESCRIPTION
Fixes issue #506.

As a side note, my IDE complained about two things while committing.

In src/Issue/IssueField.php

`Error:(5, 5) 'AllowDynamicProperties' is available starting with 8.2 PHP version.` 
The project lists 8.0 as the minimum PHP version

and

`Warning:(125, 13) Statement has empty body`
I wasn't entirely clear on what should be happening, but inverting the logic of the first if expression and anding the second expression should result in the same thing? 

            if ($this->assignee->isWantUnassigned() !== true && $this->assignee->isEmpty()) {
                unset($vars['assignee']);
            }

But that goes against what the comment says "do nothing" so I'm not sure what the intent is here.

If you want, I can open new issues for these two items.