### PR TITLE
Set types correctly for Version class

### DIFF
--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -11,7 +11,7 @@ class Version implements \JsonSerializable
     public string $id;
 
     // Version name: ex: 4.2.3
-    public ?string $name;
+    public string $name;
 
     // version description: ex; improvement performance
     public ?string $description = null;

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -20,7 +20,7 @@ class Version implements \JsonSerializable
 
     public bool $released;
 
-    public string $releaseDate;
+    public ?string $releaseDate = null;
 
     public bool $overdue = false;
 

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -14,7 +14,7 @@ class Version implements \JsonSerializable
     public ?string $name;
 
     // version description: ex; improvement performance
-    public ?string $description;
+    public ?string $description = null;
 
     public bool $archived;
 
@@ -22,14 +22,14 @@ class Version implements \JsonSerializable
 
     public string $releaseDate;
 
-    public bool $overdue;
+    public bool $overdue = false;
 
-    public ?string $userReleaseDate;
+    public ?string $userReleaseDate = null;
 
     public int $projectId;
 
-    public ?string $startDate;
-    public ?string $userStartDate;
+    public ?string $startDate = null;
+    public ?string $userStartDate = null;
 
     public function __construct($name = null)
     {


### PR DESCRIPTION
The Version class is not correctly typed. 

The `name` property is always required and can not be null. Or I do not get it where it could be nullable, because when you create a version a name is required. 

The `releaseDate` is nullable, you must not set a release date when you create or update a version. 

I also added default values for all typed properties because Jira does not sent them all when you create a empty version with just a name.

```
{
"self": "redacted/rest/api/2/version/14974",
"id": "14974",
"name": "v1.2",
"archived": false,
"released": false,
"projectId": 10028
}
``` 

Last but not least, thank you for the fast fix of 5.5.1.

If you have any questions, just let me know. 