### PR TITLE
Add cURL proxy type configuration

### DIFF
--- a/src/Configuration/AbstractConfiguration.php
+++ b/src/Configuration/AbstractConfiguration.php
@@ -65,6 +65,11 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     protected ?string $proxyPort = null;
 
     /**
+     * Proxy type.
+     */
+    protected ?int $proxyType = null;
+
+    /**
      * Proxy user.
      */
     protected ?string $proxyUser = null;
@@ -196,6 +201,11 @@ abstract class AbstractConfiguration implements ConfigurationInterface
     public function getProxyPort(): ?string
     {
         return $this->proxyPort;
+    }
+
+    public function getProxyType(): ?int
+    {
+        return $this->proxyType;
     }
 
     public function getProxyUser(): ?string

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -97,6 +97,11 @@ interface ConfigurationInterface
     public function getProxyPort(): ?string;
 
     /**
+     * Proxy type.
+     */
+    public function getProxyType(): ?int;
+
+    /**
      * Proxy user.
      */
     public function getProxyUser(): ?string;

--- a/src/Configuration/DotEnvConfiguration.php
+++ b/src/Configuration/DotEnvConfiguration.php
@@ -37,6 +37,7 @@ class DotEnvConfiguration extends AbstractConfiguration
         $this->curlOptVerbose = $this->env('CURLOPT_VERBOSE', false);
         $this->proxyServer = $this->env('PROXY_SERVER');
         $this->proxyPort = $this->env('PROXY_PORT');
+        $this->proxyType = $this->env('PROXY_TYPE');
         $this->proxyUser = $this->env('PROXY_USER');
         $this->proxyPassword = $this->env('PROXY_PASSWORD');
 

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -605,6 +605,11 @@ class JiraClient
             $password = $this->getConfiguration()->getProxyPassword();
             curl_setopt($ch, CURLOPT_PROXYUSERPWD, "$username:$password");
         }
+
+        // Set the proxy type for curl, default is CURLPROXY_HTTP (0)
+        if ($this->getConfiguration()->getProxyType()) {
+            curl_setopt($ch, CURLOPT_PROXYTYPE, $this->getConfiguration()->getProxyType());
+        }
     }
 
     /**


### PR DESCRIPTION
Allows the use of other cURL proxy types besides CURLPROXY_HTTP, e.g. CURLPROXY_SOCKS5.