### PR TITLE
Fix constructor for Version class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "netresearch/jsonmapper": "^3.0|^4.0|^5.0",
+        "netresearch/jsonmapper": "^4.2",
         "monolog/monolog": "^2.0|^3.0"
     },
     "suggest": {

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -11,7 +11,7 @@ class Version implements \JsonSerializable
     public string $id;
 
     // Version name: ex: 4.2.3
-    public ?string $name;
+    public string $name;
 
     // version description: ex; improvement performance
     public ?string $description = null;

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -20,7 +20,7 @@ class Version implements \JsonSerializable
 
     public bool $released;
 
-    public string $releaseDate;
+    public ?string $releaseDate = null;
 
     public bool $overdue = false;
 

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -31,7 +31,7 @@ class Version implements \JsonSerializable
     public ?string $startDate = null;
     public ?string $userStartDate = null;
 
-    public function __construct($name = null)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/src/Issue/Version.php
+++ b/src/Issue/Version.php
@@ -14,7 +14,7 @@ class Version implements \JsonSerializable
     public ?string $name;
 
     // version description: ex; improvement performance
-    public ?string $description;
+    public ?string $description = null;
 
     public bool $archived;
 
@@ -22,14 +22,14 @@ class Version implements \JsonSerializable
 
     public string $releaseDate;
 
-    public bool $overdue;
+    public bool $overdue = false;
 
-    public ?string $userReleaseDate;
+    public ?string $userReleaseDate = null;
 
     public int $projectId;
 
-    public ?string $startDate;
-    public ?string $userStartDate;
+    public ?string $startDate = null;
+    public ?string $userStartDate = null;
 
     public function __construct($name = null)
     {

--- a/src/Version/VersionService.php
+++ b/src/Version/VersionService.php
@@ -35,7 +35,7 @@ class VersionService extends \JiraRestApi\JiraClient
 
         return $this->json_mapper->map(
             json_decode($ret),
-            new Version()
+            Version::class
         );
     }
 
@@ -71,7 +71,7 @@ class VersionService extends \JiraRestApi\JiraClient
 
         return $this->json_mapper->map(
             json_decode($ret),
-            new Version()
+            Version::class
         );
     }
 
@@ -100,7 +100,7 @@ class VersionService extends \JiraRestApi\JiraClient
 
         return $this->json_mapper->map(
             json_decode($ret),
-            new Version()
+            Version::class
         );
     }
 


### PR DESCRIPTION
I'm sorry, I should have seen this before. 

```
error	12-Sep-2023 10:01:52	PHP Fatal error:  Uncaught TypeError: Cannot assign null to property JiraRestApi\Issue\Version::$name of type string in /home/bamboo/bamboo-home/local-working-dir/44564481/API-ACUR-JOB1/release-script/vendor/lesstif/php-jira-rest-client/src/Issue/Version.php:36
error	12-Sep-2023 10:01:52	Stack trace:
error	12-Sep-2023 10:01:52	#0 [internal function]: JiraRestApi\Issue\Version->__construct()
error	12-Sep-2023 10:01:52	#1 /home/bamboo/bamboo-home/local-working-dir/44564481/API-ACUR-JOB1/release-script/vendor/netresearch/jsonmapper/src/JsonMapper.php(685): ReflectionClass->newInstance()
```

`name` can only be a string so there should not be any default null value.

But to get this working we would need the latest version of the json mapper because I added there the functionality to provide a class-string. 

There is no version 5.0 that is why I removed it.  

If you do not want to drop support for the old json mapper versions we would need to either use Reflection to instantiated the class without constructor oder `name` must be nullable again. 

Sorry again for the mistake. 
