### PR TITLE
Introduce timeout to cURL exec from .env file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lesstif/php-jira-rest-client",
+    "name": "publicplan/php-jira-rest-client",
     "description": "JIRA REST API Client for PHP Users.",
     "type": "library",
     "keywords": ["jira", "rest", "jira-php", "jira-rest"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "publicplan/php-jira-rest-client",
+    "name": "lesstif/php-jira-rest-client",
     "description": "JIRA REST API Client for PHP Users.",
     "type": "library",
     "keywords": ["jira", "rest", "jira-php", "jira-rest"],

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -197,6 +197,8 @@ class JiraClient
 
         curl_reset($this->curl);
         $ch = $this->curl;
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->configuration->getTimeout());
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->configuration->getTimeout());
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_URL, $url);
 


### PR DESCRIPTION
Currently the Jira timeout settings are not set in `JiraClient::exec()`. So the requests can take very long. Since the default is set to 30 seconds. In my case I am injecting this configuration values to `\JiraRestApi\Configuration\ArrayConfiguration::__construct()`. This PR improves this.