### PR TITLE
Add New Method for Returning Board List With Offset/Paginated Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -2470,6 +2470,43 @@ try {
 }
 
 ```
+
+#### Get boards
+[See Jira API reference](https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-board-get)
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use JiraRestApi\Board\BoardService;
+
+try {
+  $results = [];
+  $startAt = 0;
+  $maxResults = 50; // maximum allowed for board queries
+
+  do {
+      $response = $this->boardService->getBoards([
+        'startAt' => $startAt,
+        'maxResults' => $maxResults
+      ]);
+
+      $results = [...$results, ...$response->getBoards()];
+
+      $startAt += $maxResults;
+
+  } while($startAt < $response->total);
+  
+  var_dump($results);
+  
+} catch (JiraRestApi\JiraException $e) {
+    print('Error Occured! ' . $e->getMessage());
+}
+
+```
+
+
+
 #### Get board info
 [See Jira API reference](https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-board-boardId-get)
 

--- a/src/Board/BoardResult.php
+++ b/src/Board/BoardResult.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace JiraRestApi\Board;
+
+/**
+ * Result object for BoardService::getBoards()
+ */
+class BoardResult
+{
+    /**
+     * @var string
+     */
+    public $expand;
+
+    /**
+     * @var int
+     */
+    public $startAt;
+
+    /**
+     * @var int
+     */
+    public $maxResults;
+
+    /**
+     * @var int
+     */
+    public $total;
+
+    /**
+     * @var \JiraRestApi\Board\Board[]
+     */
+    public $values;
+
+    /**
+     * @var bool
+     */
+    public $isLast;
+
+    /**
+     * @return int
+     */
+    public function getStartAt()
+    {
+        return $this->startAt;
+    }
+
+    /**
+     * @param int $startAt
+     */
+    public function setStartAt($startAt)
+    {
+        $this->startAt = $startAt;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
+    }
+
+    /**
+     * @param int $maxResults
+     */
+    public function setMaxResults($maxResults)
+    {
+        $this->maxResults = $maxResults;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     * @param int $total
+     */
+    public function setTotal($total)
+    {
+        $this->total = $total;
+    }
+
+    /**
+     * @return Board[]
+     */
+    public function getBoards()
+    {
+        return $this->values;
+    }
+
+    /**
+     * @param Board[] $boards
+     */
+    public function setBoards($boards)
+    {
+        $this->values = $boards;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return Board
+     */
+    public function getBoard($index)
+    {
+        return $this->values[$index];
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpand()
+    {
+        return $this->expand;
+    }
+
+    /**
+     * @param string $expand
+     */
+    public function setExpand($expand)
+    {
+        $this->expand = $expand;
+    }
+}

--- a/src/Board/BoardResult.php
+++ b/src/Board/BoardResult.php
@@ -3,7 +3,7 @@
 namespace JiraRestApi\Board;
 
 /**
- * Result object for BoardService::getBoards()
+ * Result object for BoardService::getBoards().
  */
 class BoardResult
 {

--- a/src/Board/BoardService.php
+++ b/src/Board/BoardService.php
@@ -46,6 +46,29 @@ class BoardService extends \JiraRestApi\JiraClient
         }
     }
 
+    /**
+     * Get list of boards with paginated results
+     *
+     * @param array $paramArray
+     *
+     * @throws \JiraRestApi\JiraException
+     *
+     * @return BoardResult|null array of Board class
+     */
+    public function getBoards($paramArray = []): ?BoardResult
+    {
+        $json = $this->exec($this->uri.$this->toHttpQueryParameter($paramArray), null);
+        try {
+            return $this->json_mapper->map(
+                json_decode($json, false, 512, $this->getJsonOptions()),
+                new BoardResult()
+            );
+        } catch (\JsonException $exception) {
+            $this->log->error("Response cannot be decoded from json\nException: {$exception->getMessage()}");
+            return null;
+        }
+    }
+
     public function getBoard($id, $paramArray = []): ?Board
     {
         $json = $this->exec($this->uri.'/'.$id.$this->toHttpQueryParameter($paramArray), null);

--- a/src/Board/BoardService.php
+++ b/src/Board/BoardService.php
@@ -47,7 +47,7 @@ class BoardService extends \JiraRestApi\JiraClient
     }
 
     /**
-     * Get list of boards with paginated results
+     * Get list of boards with paginated results.
      *
      * @param array $paramArray
      *

--- a/src/Board/BoardService.php
+++ b/src/Board/BoardService.php
@@ -51,17 +51,17 @@ class BoardService extends \JiraRestApi\JiraClient
      *
      * @param array $paramArray
      *
-     * @throws \JiraRestApi\JiraException
+     * @return PaginatedResult|null array of Board class
+     *@throws \JiraRestApi\JiraException
      *
-     * @return BoardResult|null array of Board class
      */
-    public function getBoards($paramArray = []): ?BoardResult
+    public function getBoards($paramArray = []): ?PaginatedResult
     {
         $json = $this->exec($this->uri.$this->toHttpQueryParameter($paramArray), null);
         try {
             return $this->json_mapper->map(
                 json_decode($json, false, 512, $this->getJsonOptions()),
-                new BoardResult()
+                new PaginatedResult()
             );
         } catch (\JsonException $exception) {
             $this->log->error("Response cannot be decoded from json\nException: {$exception->getMessage()}");
@@ -141,6 +141,30 @@ class BoardService extends \JiraRestApi\JiraClient
         } catch (\JsonException $exception) {
             $this->log->error("Response cannot be decoded from json\nException: {$exception->getMessage()}");
 
+            return null;
+        }
+    }
+
+    /**
+     * Get list of boards with paginated results.
+     *
+     * @param array $paramArray
+     *
+     * @throws \JiraRestApi\JiraException
+     *
+     * @return PaginatedResult|null array of Board class
+     */
+    public function getSprintsForBoard($boardId, $paramArray = []): ?PaginatedResult
+    {
+        $json = $this->exec($this->uri.'/'.$boardId.'/sprint'.$this->toHttpQueryParameter($paramArray), null);
+
+        try {
+            return $this->json_mapper->map(
+                json_decode($json, false, 512, $this->getJsonOptions()),
+                new PaginatedResult()
+            );
+        } catch (\JsonException $exception) {
+            $this->log->error("Response cannot be decoded from json\nException: {$exception->getMessage()}");
             return null;
         }
     }

--- a/src/Board/PaginatedResult.php
+++ b/src/Board/PaginatedResult.php
@@ -3,9 +3,9 @@
 namespace JiraRestApi\Board;
 
 /**
- * Result object for BoardService::getBoards().
+ * Paginated Result object for BoardService
  */
-class BoardResult
+class PaginatedResult
 {
     /**
      * @var string
@@ -28,7 +28,7 @@ class BoardResult
     public $total;
 
     /**
-     * @var \JiraRestApi\Board\Board[]
+     * @var array
      */
     public $values;
 
@@ -86,27 +86,27 @@ class BoardResult
     }
 
     /**
-     * @return Board[]
+     * @return array
      */
-    public function getBoards()
+    public function getValues()
     {
         return $this->values;
     }
 
     /**
-     * @param Board[] $boards
+     * @param array $values
      */
-    public function setBoards($boards)
+    public function setValues($values)
     {
-        $this->values = $boards;
+        $this->values = $values;
     }
 
     /**
      * @param int $index
      *
-     * @return Board
+     * @return mixed
      */
-    public function getBoard($index)
+    public function getValue($index)
     {
         return $this->values[$index];
     }

--- a/tests/BoardTest.php
+++ b/tests/BoardTest.php
@@ -44,6 +44,31 @@ class BoardTest extends TestCase
     /**
      * @test
      *
+     * Test we can obtain the paginated board list.
+     */
+    public function get_boards() : string
+    {
+        $board_service = new BoardService();
+
+        $board_list = $board_service->getBoards();
+        $this->assertInstanceOf(BoardResult::class, $board_list, 'We receive a board list.');
+
+        $last_board_id = null;
+        foreach ($board_list->getBoards() as $board) {
+            $this->assertInstanceOf(Board::class, $board, 'Each element of the list is a Board instance.');
+            $this->assertNotNull($board->self, 'self must not null');
+            $this->assertNotNull($board->name, 'name must not null');
+            $this->assertNotNull($board->type, 'type must not null');
+
+            $last_board_id = $board->id;
+        }
+
+        return $last_board_id;
+    }
+
+    /**
+     * @test
+     *
      * @depends get_all_boards
      *
      * Test we can obtain a single board.


### PR DESCRIPTION
The current implementation of the `BoardService->getBoardList()` method will only return the first 50 results from the Jira Board endpoint (`/rest/agile/1.0/board`). 

Rather than modify the existing `getBoardList()` method and introduce a breaking change, I created a new method -- `getBoards()` -- which maps the response data from `/rest/agile/1.0/board` into a newly created BoardResult object.  This new object has properties for data like total results, and a `isLast` boolean, which are returned by the endpoint but currently ignored by `getBoardList()`. 

Using this new object data, developers can easily make multiple calls to the `/rest/agile/1.0/board` endpoint to retrieve the entire list of boards rather than just the first 50. 

I added this information to the ReadMe and added an additional test. 

Let me know what you think. 

Thanks.  
