### PR TITLE
feat: added endpoint to find workload by ID

### DIFF
--- a/src/ServiceDesk/Request/RequestService.php
+++ b/src/ServiceDesk/Request/RequestService.php
@@ -428,6 +428,26 @@ class RequestService
     }
 
     /**
+     * @param array<int> $ids
+     *
+     * @return array<Worklog>
+     */
+    public function getWorklogsByIds(array $ids): array
+    {
+        $ret = $this->client->exec('/worklog/list', json_encode(['ids' => $ids]), 'POST');
+
+        $this->logger->debug("getWorklogsByIds res=$ret\n");
+
+        $worklogsResponse = json_decode($ret, false, 512, JSON_THROW_ON_ERROR);
+
+        $worklogs = array_map(function ($worklog) {
+            return $this->jsonMapper->map($worklog, new Worklog());
+        }, $worklogsResponse);
+
+        return $worklogs;
+    }
+
+    /**
      * add work log to issue.
      *
      * @throws JsonMapper_Exception|JiraException|JsonException

--- a/tests/ServiceDesk/Request/RequestServiceTest.php
+++ b/tests/ServiceDesk/Request/RequestServiceTest.php
@@ -369,6 +369,33 @@ class RequestServiceTest extends TestCase
         self::assertSame($item->timeSpent, $result->timeSpent);
     }
 
+	public function testGetWorklogsByIds(): void
+	{
+		$item1 = new stdClass();
+		$item1->id = 25;
+		$item1->timeSpent = '2 hours';
+
+		$item2 = new stdClass();
+		$item2->id = 50;
+		$item2->timeSpent = '2 hours';
+
+
+		$items = [
+			$item1,
+			$item2,
+		];
+
+		$this->client->method('exec')
+			->with("/worklog/list", json_encode(['ids' => [25, 50]]), 'POST')
+			->willReturn(json_encode($items));
+
+		$result = $this->uut->getWorklogsByIds([25, 50]);
+
+		self::assertSame(2, count($result));
+		self::assertSame($item1->timeSpent, $result[0]->timeSpent);
+
+	}
+
     public function testAddWorklog(): void
     {
         $item = $this->createWorkflow(25, '2 hours');


### PR DESCRIPTION
Accessing [endpoint](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-worklogs/#api-rest-api-2-worklog-list-post) to find worklog location using just its id.