### PR TITLE
Set default values for changelog + fixVersions

### DIFF
--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -29,7 +29,7 @@ class Issue implements \JsonSerializable
 
     public ?array $editmeta;
 
-    public ?ChangeLog $changelog;
+    public ?ChangeLog $changelog = null;
 
     #[\ReturnTypeWillChange]
     public function jsonSerialize(): array

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -47,7 +47,7 @@ class IssueField implements \JsonSerializable
 
     public ?object $resolution;
 
-    public array $fixVersions;
+    public array $fixVersions = [];
 
     public ?Reporter $creator;
 


### PR DESCRIPTION
`Changelog` and `fixVersions` are not initialized if the fields are empty in Jira.

This causes `Typed property must not be accessed before initialization` errors on our side.