### PR TITLE
Set default to null for all nullable properties

### DIFF
--- a/src/Component/Component.php
+++ b/src/Component/Component.php
@@ -25,7 +25,7 @@ class Component implements \JsonSerializable
 
     public string $description;
 
-    public ?User $lead;
+    public ?User $lead = null;
 
     public string $leadUserName;
 

--- a/src/Issue/Issue.php
+++ b/src/Issue/Issue.php
@@ -7,7 +7,7 @@ class Issue implements \JsonSerializable
     /**
      * return only if Project query by key(not id).
      */
-    public ?string $expand;
+    public ?string $expand = null;
 
     public string $self;
 
@@ -17,19 +17,19 @@ class Issue implements \JsonSerializable
 
     public IssueField $fields;
 
-    public ?array $renderedFields;
+    public ?array $renderedFields = null;
 
-    public ?array $names;
+    public ?array $names = null;
 
-    public ?array $schema;
+    public ?array $schema = null;
 
-    public ?array $transitions;
+    public ?array $transitions = null;
 
-    public ?array $operations;
+    public ?array $operations = null;
 
-    public ?array $editmeta;
+    public ?array $editmeta = null;
 
-    public ?ChangeLog $changelog;
+    public ?ChangeLog $changelog = null;
 
     #[\ReturnTypeWillChange]
     public function jsonSerialize(): array

--- a/src/Issue/IssueField.php
+++ b/src/Issue/IssueField.php
@@ -18,11 +18,11 @@ class IssueField implements \JsonSerializable
 
     public ?TimeTracking $timeTracking = null;
 
-    public ?IssueType $issuetype;
+    public ?IssueType $issuetype = null;
 
     public ?Reporter $reporter = null;
 
-    public ?DateTimeInterface $created;
+    public ?DateTimeInterface $created = null;
 
     public ?DateTimeInterface $updated = null;
 
@@ -36,7 +36,7 @@ class IssueField implements \JsonSerializable
 
     public Project $project;
 
-    public ?string $environment;
+    public ?string $environment = null;
 
     /* @var \JiraRestApi\Issue\Component[] This property must don't describe the type feature for JSON deserialized. */
     public $components;
@@ -45,15 +45,15 @@ class IssueField implements \JsonSerializable
 
     public object $votes;
 
-    public ?object $resolution;
+    public ?object $resolution = null;
 
     public array $fixVersions;
 
-    public ?Reporter $creator;
+    public ?Reporter $creator = null;
 
-    public ?object $watches;
+    public ?object $watches = null;
 
-    public ?object $worklog;
+    public ?object $worklog = null;
 
     public ?Reporter $assignee = null;
 
@@ -63,13 +63,13 @@ class IssueField implements \JsonSerializable
     /** @var \JiraRestApi\Issue\Attachment[] */
     public $attachment;
 
-    public ?string $aggregatetimespent;
+    public ?string $aggregatetimespent = null;
 
-    public ?string $timeestimate;
+    public ?string $timeestimate = null;
 
-    public ?string $aggregatetimeoriginalestimate;
+    public ?string $aggregatetimeoriginalestimate = null;
 
-    public ?string $resolutiondate;
+    public ?string $resolutiondate = null;
 
     public ?DateTimeInterface $duedate = null;
 
@@ -82,20 +82,20 @@ class IssueField implements \JsonSerializable
 
     public int $workratio;
 
-    public ?object $aggregatetimeestimate;
+    public ?object $aggregatetimeestimate = null;
 
-    public ?object $aggregateprogress;
+    public ?object $aggregateprogress = null;
 
-    public ?object $lastViewed;
+    public ?object $lastViewed = null;
 
-    public ?object $timeoriginalestimate;
+    public ?object $timeoriginalestimate = null;
 
     /** @var object|null */
     public $parent;
 
-    public ?array $customFields;
+    public ?array $customFields = null;
 
-    public ?SecurityScheme $security;
+    public ?SecurityScheme $security = null;
 
     public function __construct($updateIssue = false)
     {

--- a/src/Issue/IssueType.php
+++ b/src/Issue/IssueType.php
@@ -8,7 +8,7 @@ class IssueType implements \JsonSerializable
 
     public string $id;
 
-    public ?string $description;
+    public ?string $description = null;
 
     public string $iconUrl;
 

--- a/src/Issue/Reporter.php
+++ b/src/Issue/Reporter.php
@@ -14,7 +14,7 @@ class Reporter implements \JsonSerializable
 
     public string $self;
 
-    public ?string $name;
+    public ?string $name = null;
 
     public ?string $emailAddress = null;
 

--- a/src/Project/Project.php
+++ b/src/Project/Project.php
@@ -28,7 +28,7 @@ class Project implements \JsonSerializable
     /**
      * Project key.
      */
-    public ?string $key;
+    public ?string $key = null;
 
     /**
      * Project name.
@@ -73,17 +73,17 @@ class Project implements \JsonSerializable
      */
     public $issueTypes;
 
-    public ?string $assigneeType;
+    public ?string $assigneeType = null;
 
     public ?array $versions = [];
 
-    public ?array $roles;
+    public ?array $roles = null;
 
     public string $url;
 
     public string $projectTypeKey;
 
-    public ?string $projectTemplateKey;
+    public ?string $projectTemplateKey = null;
 
     public int $avatarId;
 

--- a/src/ServiceDesk/Customer/Customer.php
+++ b/src/ServiceDesk/Customer/Customer.php
@@ -20,7 +20,7 @@ class Customer implements JsonSerializable
     public string $displayName;
     public bool $active;
     public string $timeZone;
-    public ?CustomerLinks $_links;
+    public ?CustomerLinks $_links = null;
     public string $self;
 
     public function setLinks($links): void


### PR DESCRIPTION
This PR is similar to #543, but sets the default values for all nullable properties.

This fixes php errors in the form of:

```
Typed property JiraRestApi\Issue\IssueField::$resolution must not be accessed before initialization
```