### PR TITLE
Fix: `expand` property in IssueSearchResult not nullable

### DIFF
--- a/src/Issue/IssueSearchResult.php
+++ b/src/Issue/IssueSearchResult.php
@@ -17,7 +17,7 @@ class IssueSearchResult
     /**
      * @var string
      */
-    public $expand;
+    public ?string $expand = null;
 
     /**
      * @var int
@@ -114,17 +114,14 @@ class IssueSearchResult
     }
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getExpand()
     {
         return $this->expand;
     }
 
-    /**
-     * @param string $expand
-     */
-    public function setExpand($expand)
+    public function setExpand(?string $expand)
     {
         $this->expand = $expand;
     }


### PR DESCRIPTION
It seems Jira was updated. 
Jira now returns the `expand` property with a null value. 
Appearently, the JsonMapper takes issue with this, resulting in this error:

`Fix ["JSON property \"expand\" in class \"JiraRestApi\\Issue\\IssueSearchResult\" must not be NULL"]`

This change makes the `expand` field accept null values.