### PR TITLE
Share DNS and Connect between curl requests

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -160,6 +160,18 @@ class JiraClient
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConfiguration()->getTimeout());
         }
 
+        if (\function_exists('curl_share_init_persistent')) {
+            $share = curl_share_init_persistent([
+                CURL_LOCK_DATA_DNS,
+                CURL_LOCK_DATA_CONNECT,
+            ]);
+        } else {
+            $share = curl_share_init();
+            curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+            curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+        }
+        curl_setopt($ch, CURLOPT_SHARE, $share);
+
         return $curl_http_headers;
     }
 

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -38,7 +38,7 @@ class JiraClient
     /**
      * CURL share instance.
      */
-    protected \CurlShareHandle $curlShare = null;
+    protected \CurlShareHandle|\CurlSharePersistentHandle|null $curlShare = null;
 
     /**
      * Monolog instance.

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -34,7 +34,7 @@ class JiraClient
      * CURL instance.
      */
     protected \CurlHandle $curl;
-
+    
     protected \CurlShareHandle $curlShare = null;
     
     /**

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -35,6 +35,8 @@ class JiraClient
      */
     protected \CurlHandle $curl;
 
+    protected \CurlShareHandle $curlShare = null;
+    
     /**
      * Monolog instance.
      */
@@ -160,17 +162,19 @@ class JiraClient
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConfiguration()->getTimeout());
         }
 
-        if (\function_exists('curl_share_init_persistent')) {
-            $share = curl_share_init_persistent([
-                CURL_LOCK_DATA_DNS,
-                CURL_LOCK_DATA_CONNECT,
-            ]);
-        } else {
-            $share = curl_share_init();
-            curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
-            curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+        if ($this->curlShare === null) {
+            if (\function_exists('curl_share_init_persistent')) {
+                $this->curlShare = curl_share_init_persistent([
+                    CURL_LOCK_DATA_DNS,
+                    CURL_LOCK_DATA_CONNECT,
+                ]);
+            } else {
+                $this->curlShare = curl_share_init();
+                curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+                curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+            }
         }
-        curl_setopt($ch, CURLOPT_SHARE, $share);
+        curl_setopt($ch, CURLOPT_SHARE, $this->curlShare);
 
         return $curl_http_headers;
     }

--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -34,9 +34,12 @@ class JiraClient
      * CURL instance.
      */
     protected \CurlHandle $curl;
-    
+
+    /**
+     * CURL share instance.
+     */
     protected \CurlShareHandle $curlShare = null;
-    
+
     /**
      * Monolog instance.
      */


### PR DESCRIPTION
reduces overhead when doing multiple curl requests per php-request.
starting with PHP 8.5 this even allows caching across php-requests.

other places which manually invoke `curl_init` can benefit in a similar way by adding such code. `curl_multi_*` will automatically share caches between requests, without the need for additional code.

we could also add `CURL_LOCK_DATA_SSL_SESSION`, but I was not sure whether this has security implications. therefore I left it out for now.

analog https://github.com/lesstif/php-JiraCloud-RESTAPI/pull/117